### PR TITLE
ELCC 2: Add Pull Request and Issue Templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,33 @@
+---
+name: Default
+about: Adding a feature or fixing a bug in this project
+title: ""
+labels: ""
+assignees: ""
+---
+
+Depends on:
+
+- (delete this section if pull request has no dependencies)
+
+Fixes (link to Jira ticket or github issue)
+
+# Context
+
+(detailed context about the issue the pull request is solving)
+
+# Implemenation
+
+(and specific implementation details that are worthy of note or might need explanation)
+
+# Screenshots
+
+(if making UI changes add screenshots comparing the old and new experience)
+
+# Testing Instructions
+
+1. Boot the app via `dev up`
+
+2. Check that the app complies, and that you can log in at http://localhost:8080.
+
+3. Check that you can do ...

--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,7 +1,7 @@
 ---
 name: Default
 about: Adding a feature or fixing a bug in this project
-title: ""
+title: "ELCC XXX: ..."
 labels: ""
 assignees: ""
 ---


### PR DESCRIPTION
Fixes https://yg-hpw.atlassian.net/browse/ELCC-2

# Context

In the past I've found it helps to keep me focused on smaller solutions when I have a Pull Request and Issue template.

See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository

# Testing Instructions

1. Begin the issue creation wizard in the repo and see what it looks like. I _think_ this will only work once changes are in `main`?
2. Do the same with the PR template. I _think_ this will only work once changes are in `main`?
