### PR TITLE
ELCC-5: Establish Appropriate TimeStamp Columns In Database

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Fixes (link to Jira ticket or github issue)
 
 (detailed context about the issue the pull request is solving)
 
-# Implemenation
+# Implementation
 
 (and specific implementation details that are worthy of note or might need explanation)
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^0.27.2",
+        "cls-hooked": "^4.2.2",
         "cors": "^2.8.5",
         "dotenv": "^16.0.2",
         "express": "^4.18.1",
@@ -27,6 +28,7 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^8.0.2",
+        "@types/cls-hooked": "^4.3.6",
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.14",
         "@types/express-jwt": "^6.0.4",
@@ -1906,6 +1908,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cls-hooked": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.6.tgz",
+      "integrity": "sha512-Ys46tagI3aFwFizHYwG2v0oS+mMfp1nubY2ETU/RY/D0jLOXpqqVEItjhOmKMI8SklF3MI4Y7oSp9UFkBk4CXQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -2745,6 +2756,17 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
+    "node_modules/async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "dependencies": {
+        "stack-chain": "^1.3.7"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3211,6 +3233,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "dependencies": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3537,6 +3572,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.511.tgz",
       "integrity": "sha512-udHyLfdy390CObLy3uFQitCBvK+WxWu6WZWQMBzO/npNiRy6tanDKR1c/F6OImfAiSt1ylgNszPJBxix2c0w3w==",
       "dev": true
+    },
+    "node_modules/emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "dependencies": {
+        "shimmer": "^1.2.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -7499,6 +7542,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -7563,6 +7611,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "node_modules/stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -10141,6 +10194,15 @@
         "@types/node": "*"
       }
     },
+    "@types/cls-hooked": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.6.tgz",
+      "integrity": "sha512-Ys46tagI3aFwFizHYwG2v0oS+mMfp1nubY2ETU/RY/D0jLOXpqqVEItjhOmKMI8SklF3MI4Y7oSp9UFkBk4CXQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -10778,6 +10840,14 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "requires": {
+        "stack-chain": "^1.3.7"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -11091,6 +11161,16 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -11342,6 +11422,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.511.tgz",
       "integrity": "sha512-udHyLfdy390CObLy3uFQitCBvK+WxWu6WZWQMBzO/npNiRy6tanDKR1c/F6OImfAiSt1ylgNszPJBxix2c0w3w==",
       "dev": true
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "requires": {
+        "shimmer": "^1.2.0"
+      }
     },
     "emittery": {
       "version": "0.13.1",
@@ -14208,6 +14296,11 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -14260,6 +14353,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "stack-utils": {
       "version": "2.0.6",

--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.27.2",
+    "cls-hooked": "^4.2.2",
     "cors": "^2.8.5",
     "dotenv": "^16.0.2",
     "express": "^4.18.1",
@@ -33,6 +34,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
+    "@types/cls-hooked": "^4.3.6",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.14",
     "@types/express-jwt": "^6.0.4",

--- a/api/src/db/db-client.ts
+++ b/api/src/db/db-client.ts
@@ -23,6 +23,7 @@ export const SEQUELIZE_CONFIG: Options = {
   logging: NODE_ENV === "development" ? console.log : false,
   define: {
     underscored: true,
+    timestamps: true, // This is actually the default, but making it explicit for clarity.
   },
 }
 

--- a/api/src/db/db-client.ts
+++ b/api/src/db/db-client.ts
@@ -21,6 +21,9 @@ export const SEQUELIZE_CONFIG: Options = {
   port: DB_PORT,
   schema: "dbo",
   logging: NODE_ENV === "development" ? console.log : false,
+  define: {
+    underscored: true,
+  },
 }
 
 const db = new Sequelize(SEQUELIZE_CONFIG)

--- a/api/src/db/db-client.ts
+++ b/api/src/db/db-client.ts
@@ -1,6 +1,10 @@
 import { Sequelize, Options } from "sequelize"
+import { createNamespace } from "cls-hooked"
 
 import { DB_HOST, DB_USER, DB_PASS, DB_NAME, DB_PORT, NODE_ENV } from "@/config"
+
+const namespace = createNamespace("sequelize-transaction-context")
+Sequelize.useCLS(namespace)
 
 if (DB_NAME === undefined) throw new Error("database name is unset.")
 if (DB_USER === undefined) throw new Error("database username is unset.")

--- a/api/src/db/migrations/2023.09.25T23.59.26.add-timestamp-columns-to-center-funding-period-table.ts
+++ b/api/src/db/migrations/2023.09.25T23.59.26.add-timestamp-columns-to-center-funding-period-table.ts
@@ -1,0 +1,20 @@
+import type { Migration } from "@/db/umzug"
+import { MssqlSimpleTypes } from "@/db/utils/mssql-simple-types"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("centre_funding_period", "created_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+  await queryInterface.addColumn("centre_funding_period", "updated_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeColumn("centre_funding_period", "created_at")
+  await queryInterface.removeColumn("centre_funding_period", "updated_at")
+}

--- a/api/src/db/migrations/2023.09.28T21.12.05.add-timestamp-columns-to-centres-table.ts
+++ b/api/src/db/migrations/2023.09.28T21.12.05.add-timestamp-columns-to-centres-table.ts
@@ -1,0 +1,69 @@
+import type { Migration } from "@/db/umzug"
+import { MssqlSimpleTypes } from "@/db/utils/mssql-simple-types"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async (transaction) => {
+    await queryInterface.addColumn(
+      "centres",
+      "created_at",
+      {
+        type: MssqlSimpleTypes.DATETIME2(),
+        allowNull: false,
+        defaultValue: MssqlSimpleTypes.NOW,
+      },
+      { transaction }
+    )
+    await queryInterface.addColumn(
+      "centres",
+      "updated_at",
+      {
+        type: MssqlSimpleTypes.DATETIME2(),
+        allowNull: false,
+        defaultValue: MssqlSimpleTypes.NOW,
+      },
+      { transaction }
+    )
+
+    await queryInterface.sequelize.query(
+      `
+    UPDATE
+      centres
+    SET
+      created_at = create_date
+    FROM
+      centres
+    `,
+      { transaction }
+    )
+    await queryInterface.removeColumn("centres", "create_date", { transaction })
+  })
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  return queryInterface.sequelize.transaction(async (transaction) => {
+    await queryInterface.addColumn(
+      "centres",
+      "create_date",
+      {
+        type: MssqlSimpleTypes.DATETIME2(0),
+        allowNull: false,
+        defaultValue: MssqlSimpleTypes.NOW,
+      },
+      { transaction }
+    )
+    await queryInterface.sequelize.query(
+      `
+    UPDATE
+      centres
+    SET
+      create_date = created_at
+    FROM
+      centres
+    `,
+      { transaction }
+    )
+
+    await queryInterface.removeColumn("centres", "created_at", { transaction })
+    await queryInterface.removeColumn("centres", "updated_at", { transaction })
+  })
+}

--- a/api/src/db/migrations/2023.09.28T23.20.38.add-timestamp-columns-to-funding-period-table.ts
+++ b/api/src/db/migrations/2023.09.28T23.20.38.add-timestamp-columns-to-funding-period-table.ts
@@ -1,0 +1,20 @@
+import type { Migration } from "@/db/umzug"
+import { MssqlSimpleTypes } from "@/db/utils/mssql-simple-types"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("funding_period", "created_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+  await queryInterface.addColumn("funding_period", "updated_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeColumn("funding_period", "created_at")
+  await queryInterface.removeColumn("funding_period", "updated_at")
+}

--- a/api/src/db/migrations/2023.09.28T23.29.57.add-timestamp-columns-to-funding-submission-line-json-table.ts
+++ b/api/src/db/migrations/2023.09.28T23.29.57.add-timestamp-columns-to-funding-submission-line-json-table.ts
@@ -1,0 +1,20 @@
+import type { Migration } from "@/db/umzug"
+import { MssqlSimpleTypes } from "@/db/utils/mssql-simple-types"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("funding_submission_line_json", "created_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+  await queryInterface.addColumn("funding_submission_line_json", "updated_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeColumn("funding_submission_line_json", "created_at")
+  await queryInterface.removeColumn("funding_submission_line_json", "updated_at")
+}

--- a/api/src/db/migrations/2023.09.28T23.32.56.add-timestamp-columns-to-funding-submission-line-value-table.ts
+++ b/api/src/db/migrations/2023.09.28T23.32.56.add-timestamp-columns-to-funding-submission-line-value-table.ts
@@ -1,0 +1,20 @@
+import type { Migration } from "@/db/umzug"
+import { MssqlSimpleTypes } from "@/db/utils/mssql-simple-types"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("funding_submission_line_value", "created_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+  await queryInterface.addColumn("funding_submission_line_value", "updated_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeColumn("funding_submission_line_value", "created_at")
+  await queryInterface.removeColumn("funding_submission_line_value", "updated_at")
+}

--- a/api/src/db/migrations/2023.09.28T23.35.15.add-timestamp-columns-to-funding-submission-line-table.ts
+++ b/api/src/db/migrations/2023.09.28T23.35.15.add-timestamp-columns-to-funding-submission-line-table.ts
@@ -1,0 +1,20 @@
+import type { Migration } from "@/db/umzug"
+import { MssqlSimpleTypes } from "@/db/utils/mssql-simple-types"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("funding_submission_line", "created_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+  await queryInterface.addColumn("funding_submission_line", "updated_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeColumn("funding_submission_line", "created_at")
+  await queryInterface.removeColumn("funding_submission_line", "updated_at")
+}

--- a/api/src/db/migrations/2023.09.28T23.37.52.add-timestamp-columns-to-logs-table.ts
+++ b/api/src/db/migrations/2023.09.28T23.37.52.add-timestamp-columns-to-logs-table.ts
@@ -1,0 +1,48 @@
+import type { Migration } from "@/db/umzug"
+import { MssqlSimpleTypes } from "@/db/utils/mssql-simple-types"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("logs", "created_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+  await queryInterface.addColumn("logs", "updated_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+
+  await queryInterface.sequelize.query(
+    `
+    UPDATE
+      logs
+    SET
+      created_at = date
+    FROM
+      logs
+    `
+  )
+  await queryInterface.removeColumn("logs", "date")
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("logs", "date", {
+    type: MssqlSimpleTypes.DATETIME2(0),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+  await queryInterface.sequelize.query(
+    `
+    UPDATE
+      logs
+    SET
+      date = created_at
+    FROM
+      logs
+    `
+  )
+
+  await queryInterface.removeColumn("logs", "created_at")
+  await queryInterface.removeColumn("logs", "updated_at")
+}

--- a/api/src/db/migrations/2023.09.28T23.46.01.add-timestamp-columns-to-user-roles-table.ts
+++ b/api/src/db/migrations/2023.09.28T23.46.01.add-timestamp-columns-to-user-roles-table.ts
@@ -1,0 +1,20 @@
+import type { Migration } from "@/db/umzug"
+import { MssqlSimpleTypes } from "@/db/utils/mssql-simple-types"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("user_roles", "created_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+  await queryInterface.addColumn("user_roles", "updated_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeColumn("user_roles", "created_at")
+  await queryInterface.removeColumn("user_roles", "updated_at")
+}

--- a/api/src/db/migrations/2023.09.28T23.48.53.add-timestamp-columns-to-users-table.ts
+++ b/api/src/db/migrations/2023.09.28T23.48.53.add-timestamp-columns-to-users-table.ts
@@ -1,0 +1,48 @@
+import type { Migration } from "@/db/umzug"
+import { MssqlSimpleTypes } from "@/db/utils/mssql-simple-types"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("users", "created_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+  await queryInterface.addColumn("users", "updated_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+
+  await queryInterface.sequelize.query(
+    `
+    UPDATE
+      users
+    SET
+      created_at = create_date
+    FROM
+      users
+    `
+  )
+  await queryInterface.removeColumn("users", "create_date")
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("users", "create_date", {
+    type: MssqlSimpleTypes.DATETIME2(0),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+  await queryInterface.sequelize.query(
+    `
+    UPDATE
+      users
+    SET
+      create_date = created_at
+    FROM
+      users
+    `
+  )
+
+  await queryInterface.removeColumn("users", "created_at")
+  await queryInterface.removeColumn("users", "updated_at")
+}

--- a/api/src/db/migrations/2023.09.28T23.58.04.add-timestamp-columns-to-sequelize-meta-table.ts
+++ b/api/src/db/migrations/2023.09.28T23.58.04.add-timestamp-columns-to-sequelize-meta-table.ts
@@ -1,0 +1,20 @@
+import type { Migration } from "@/db/umzug"
+import { MssqlSimpleTypes } from "@/db/utils/mssql-simple-types"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("SequelizeMeta", "created_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+  await queryInterface.addColumn("SequelizeMeta", "updated_at", {
+    type: MssqlSimpleTypes.DATETIME2(),
+    allowNull: false,
+    defaultValue: MssqlSimpleTypes.NOW,
+  })
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeColumn("SequelizeMeta", "created_at")
+  await queryInterface.removeColumn("SequelizeMeta", "updated_at")
+}

--- a/api/src/db/umzug.ts
+++ b/api/src/db/umzug.ts
@@ -6,10 +6,12 @@ import sequelize from "@/db/db-client"
 import * as models from "@/models"
 
 import { UmzugNullStorage } from "@/db/umzug-null-storage"
+import { sequelizeAutoTransactionResolver } from "@/db/utils/sequelize-auto-transaction-resolver"
 
 export const migrator = new Umzug({
   migrations: {
     glob: ["migrations/*.ts", { cwd: __dirname }],
+    resolve: sequelizeAutoTransactionResolver,
   },
   context: sequelize.getQueryInterface(),
   storage: new SequelizeStorage({

--- a/api/src/db/umzug.ts
+++ b/api/src/db/umzug.ts
@@ -17,7 +17,9 @@ export const migrator = new Umzug({
   storage: new SequelizeStorage({
     sequelize,
     tableName: "SequelizeMeta",
-    timestamps: true,
+    // FUTURE: 2023-10-28 enable this once api/src/db/migrations/2023.09.28T23.58.04.add-timestamp-columns-to-sequelize-meta-table.ts
+    // has run in all environments.
+    // timestamps: true,
   }),
   logger: console,
   create: {

--- a/api/src/db/umzug.ts
+++ b/api/src/db/umzug.ts
@@ -16,6 +16,8 @@ export const migrator = new Umzug({
   context: sequelize.getQueryInterface(),
   storage: new SequelizeStorage({
     sequelize,
+    tableName: "SequelizeMeta",
+    timestamps: true,
   }),
   logger: console,
   create: {

--- a/api/src/db/utils/sequelize-auto-transaction-resolver.ts
+++ b/api/src/db/utils/sequelize-auto-transaction-resolver.ts
@@ -1,0 +1,26 @@
+import { QueryInterface } from "sequelize"
+import { MigrationParams } from "umzug"
+
+export function sequelizeAutoTransactionResolver({
+  name,
+  path,
+  context,
+}: MigrationParams<QueryInterface>) {
+  if (path === undefined) throw new Error("Path is undefined")
+
+  return {
+    name,
+    up: async () => {
+      const migration = await import(path)
+      return context.sequelize.transaction(() => {
+        return migration.up({ context })
+      })
+    },
+    down: async () => {
+      const migration = await import(path)
+      return context.sequelize.transaction(() => {
+        return migration.down({ context })
+      })
+    },
+  }
+}

--- a/api/src/models/centre-funding-period.ts
+++ b/api/src/models/centre-funding-period.ts
@@ -59,6 +59,9 @@ CentreFundingPeriod.init(
         key: "id",
       },
     },
+    // TODO: rename this column if it doesn't reference a database id;
+    // probably to something like fiscalPeriodIdentifier
+    // It's generally best to restrict the *Id pattern for database ids and foreign keys
     fiscalPeriodId: {
       type: DataTypes.INTEGER,
       allowNull: false,

--- a/api/src/models/centre-funding-period.ts
+++ b/api/src/models/centre-funding-period.ts
@@ -86,7 +86,6 @@ CentreFundingPeriod.init(
   {
     sequelize,
     tableName: "centre_funding_period", // TODO: remove this once table name is pluralized
-    underscored: true,
   }
 )
 

--- a/api/src/models/centre-funding-period.ts
+++ b/api/src/models/centre-funding-period.ts
@@ -23,6 +23,8 @@ export class CentreFundingPeriod extends Model<
   declare centreId: ForeignKey<Centre["id"]>
   declare fiscalPeriodId: number
   declare notes: string
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
 
   // https://sequelize.org/docs/v6/other-topics/typescript/#usage
   // https://sequelize.org/docs/v6/core-concepts/assocs/#special-methodsmixins-added-to-instances
@@ -70,12 +72,21 @@ CentreFundingPeriod.init(
       type: DataTypes.TEXT,
       allowNull: true,
     },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
   },
   {
     sequelize,
     tableName: "centre_funding_period", // TODO: remove this once table name is pluralized
     underscored: true,
-    timestamps: false,
   }
 )
 

--- a/api/src/models/centre-funding-period.ts
+++ b/api/src/models/centre-funding-period.ts
@@ -39,7 +39,7 @@ export class CentreFundingPeriod extends Model<
     centre: Association<CentreFundingPeriod, Centre>
   }
 
-  static establishasAssociations() {
+  static establishAssociations() {
     this.belongsTo(Centre, {
       foreignKey: "centreId",
     })

--- a/api/src/models/centre-funding-period.ts
+++ b/api/src/models/centre-funding-period.ts
@@ -57,7 +57,7 @@ CentreFundingPeriod.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        model: Centre,
+        model: "centres",
         key: "id",
       },
     },

--- a/api/src/models/centre.ts
+++ b/api/src/models/centre.ts
@@ -36,7 +36,8 @@ export class Centre extends Model<InferAttributes<Centre>, InferCreationAttribut
   declare hotMeal: boolean | null
   declare licensedFor: number | null // licensed for xx number of children
   declare lastSubmission: Date | null
-  declare createDate: CreationOptional<Date>
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
 
   // https://sequelize.org/docs/v6/other-topics/typescript/#usage
   // https://sequelize.org/docs/v6/core-concepts/assocs/#foohasmanybar
@@ -204,7 +205,12 @@ Centre.init(
       type: DataTypes.DATEONLY,
       allowNull: true,
     },
-    createDate: {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
@@ -213,7 +219,6 @@ Centre.init(
   {
     sequelize,
     underscored: true,
-    timestamps: false,
   }
 )
 

--- a/api/src/models/centre.ts
+++ b/api/src/models/centre.ts
@@ -218,7 +218,6 @@ Centre.init(
   },
   {
     sequelize,
-    underscored: true,
   }
 )
 

--- a/api/src/models/centre.ts
+++ b/api/src/models/centre.ts
@@ -146,7 +146,7 @@ export class Centre extends Model<InferAttributes<Centre>, InferCreationAttribut
     fundingSubmissionLineValues: Association<Centre, FundingSubmissionLineValue>
   }
 
-  static establishasAssociations() {
+  static establishAssociations() {
     this.hasMany(CentreFundingPeriod, {
       sourceKey: "id",
       foreignKey: "centreId",

--- a/api/src/models/funding-period.ts
+++ b/api/src/models/funding-period.ts
@@ -1,4 +1,10 @@
-import { CreationOptional, DataTypes, InferAttributes, InferCreationAttributes, Model } from "sequelize"
+import {
+  CreationOptional,
+  DataTypes,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+} from "sequelize"
 
 import sequelize from "@/db/db-client"
 
@@ -13,6 +19,8 @@ export class FundingPeriod extends Model<
   declare title: string
   declare isFiscalYear: boolean
   declare isSchoolMonth: boolean
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
 }
 
 FundingPeriod.init(
@@ -49,12 +57,21 @@ FundingPeriod.init(
       allowNull: false,
       defaultValue: true,
     },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
   },
   {
     sequelize,
     tableName: "funding_period", // TODO: remove this once table name is pluralized
     underscored: true,
-    timestamps: false,
   }
 )
 

--- a/api/src/models/funding-period.ts
+++ b/api/src/models/funding-period.ts
@@ -71,7 +71,6 @@ FundingPeriod.init(
   {
     sequelize,
     tableName: "funding_period", // TODO: remove this once table name is pluralized
-    underscored: true,
   }
 )
 

--- a/api/src/models/funding-submission-line-json.ts
+++ b/api/src/models/funding-submission-line-json.ts
@@ -104,7 +104,6 @@ FundingSubmissionLineJson.init(
   {
     sequelize,
     tableName: "funding_submission_line_json", // TODO: remove this once table name is pluralized
-    underscored: true,
   }
 )
 

--- a/api/src/models/funding-submission-line-json.ts
+++ b/api/src/models/funding-submission-line-json.ts
@@ -64,7 +64,7 @@ FundingSubmissionLineJson.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        model: Centre,
+        model: "centres",
         key: "id",
       },
     },

--- a/api/src/models/funding-submission-line-json.ts
+++ b/api/src/models/funding-submission-line-json.ts
@@ -41,7 +41,7 @@ export class FundingSubmissionLineJson extends Model<
     centre: Association<FundingSubmissionLineJson, Centre>
   }
 
-  static establishasAssociations() {
+  static establishAssociations() {
     this.belongsTo(Centre, {
       foreignKey: "centreId",
     })

--- a/api/src/models/funding-submission-line-json.ts
+++ b/api/src/models/funding-submission-line-json.ts
@@ -27,6 +27,8 @@ export class FundingSubmissionLineJson extends Model<
   declare dateStart: Date
   declare dateEnd: Date
   declare values: string
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
 
   // https://sequelize.org/docs/v6/other-topics/typescript/#usage
   // https://sequelize.org/docs/v6/core-concepts/assocs/#special-methodsmixins-added-to-instances
@@ -88,12 +90,21 @@ FundingSubmissionLineJson.init(
       type: DataTypes.TEXT,
       allowNull: false,
     },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
   },
   {
     sequelize,
     tableName: "funding_submission_line_json", // TODO: remove this once table name is pluralized
     underscored: true,
-    timestamps: false,
   }
 )
 

--- a/api/src/models/funding-submission-line-value.ts
+++ b/api/src/models/funding-submission-line-value.ts
@@ -76,7 +76,7 @@ FundingSubmissionLineValue.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        model: Centre,
+        model: "centres",
         key: "id",
       },
     },
@@ -84,7 +84,7 @@ FundingSubmissionLineValue.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        model: FundingSubmissionLine,
+        model: "funding_submission_line", // TODO: pluralize this once table name is pluralized
         key: "id",
       },
     },

--- a/api/src/models/funding-submission-line-value.ts
+++ b/api/src/models/funding-submission-line-value.ts
@@ -148,7 +148,6 @@ FundingSubmissionLineValue.init(
   {
     sequelize,
     tableName: "funding_submission_line_value", // TODO: remove this once table name is pluralized
-    underscored: true,
   }
 )
 

--- a/api/src/models/funding-submission-line-value.ts
+++ b/api/src/models/funding-submission-line-value.ts
@@ -34,6 +34,8 @@ export class FundingSubmissionLineValue extends Model<
   declare childCount: number
   declare computedTotal: number
   declare isActual: boolean
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
 
   declare getCentre: BelongsToGetAssociationMixin<Centre>
   declare setCentre: BelongsToSetAssociationMixin<Centre, Centre["id"]>
@@ -132,12 +134,21 @@ FundingSubmissionLineValue.init(
       allowNull: false,
       defaultValue: true,
     },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
   },
   {
     sequelize,
     tableName: "funding_submission_line_value", // TODO: remove this once table name is pluralized
     underscored: true,
-    timestamps: false,
   }
 )
 

--- a/api/src/models/funding-submission-line.ts
+++ b/api/src/models/funding-submission-line.ts
@@ -128,7 +128,6 @@ FundingSubmissionLine.init(
   {
     sequelize,
     tableName: "funding_submission_line", // TODO: remove this once table name is pluralized
-    underscored: true,
   }
 )
 

--- a/api/src/models/funding-submission-line.ts
+++ b/api/src/models/funding-submission-line.ts
@@ -70,7 +70,7 @@ export class FundingSubmissionLine extends Model<
     values: Association<FundingSubmissionLine, FundingSubmissionLineValue>
   }
 
-  static establishasAssociations() {
+  static establishAssociations() {
     this.hasMany(FundingSubmissionLineValue, {
       sourceKey: "id",
       foreignKey: "submissionLineId",

--- a/api/src/models/funding-submission-line.ts
+++ b/api/src/models/funding-submission-line.ts
@@ -32,6 +32,8 @@ export class FundingSubmissionLine extends Model<
   declare fromAge: number | null
   declare toAge: number | null
   declare monthlyAmount: number
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
 
   declare getValues: HasManyGetAssociationsMixin<FundingSubmissionLineValue>
   declare setValues: HasManySetAssociationsMixin<
@@ -112,12 +114,21 @@ FundingSubmissionLine.init(
       type: DataTypes.FLOAT,
       allowNull: false,
     },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
   },
   {
     sequelize,
     tableName: "funding_submission_line", // TODO: remove this once table name is pluralized
     underscored: true,
-    timestamps: false,
   }
 )
 

--- a/api/src/models/index.ts
+++ b/api/src/models/index.ts
@@ -8,13 +8,13 @@ import FundingSubmissionLineValue from "@/models/funding-submission-line-value"
 import User from "@/models/user"
 import UserRole from "@/models/user-role"
 
-Centre.establishasAssociations()
-CentreFundingPeriod.establishasAssociations()
-FundingSubmissionLine.establishasAssociations()
-FundingSubmissionLineJson.establishasAssociations()
+Centre.establishAssociations()
+CentreFundingPeriod.establishAssociations()
+FundingSubmissionLine.establishAssociations()
+FundingSubmissionLineJson.establishAssociations()
 FundingSubmissionLineValue.establishAssociations()
-User.establishasAssociations()
-UserRole.establishasAssociations()
+User.establishAssociations()
+UserRole.establishAssociations()
 
 export * from "@/models/centre-funding-period"
 export * from "@/models/centre"

--- a/api/src/models/log.ts
+++ b/api/src/models/log.ts
@@ -61,7 +61,6 @@ Log.init(
   },
   {
     sequelize,
-    underscored: true,
   }
 )
 

--- a/api/src/models/log.ts
+++ b/api/src/models/log.ts
@@ -15,12 +15,13 @@ export enum LogOperationTypes {
 }
 
 export class Log extends Model<InferAttributes<Log>, InferCreationAttributes<Log>> {
-  public declare id: CreationOptional<number>
-  public declare tableName: string
-  public declare operation: string
-  public declare userEmail: string
-  public declare data: string
-  public declare date: CreationOptional<Date>
+  declare id: CreationOptional<number>
+  declare tableName: string
+  declare operation: string
+  declare userEmail: string
+  declare data: string
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
 }
 
 Log.init(
@@ -47,7 +48,12 @@ Log.init(
       type: DataTypes.STRING(2000),
       allowNull: false,
     },
-    date: {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
@@ -56,7 +62,6 @@ Log.init(
   {
     sequelize,
     underscored: true,
-    timestamps: false,
   }
 )
 

--- a/api/src/models/user-role.ts
+++ b/api/src/models/user-role.ts
@@ -43,9 +43,7 @@ export class UserRole extends Model<InferAttributes<UserRole>, InferCreationAttr
   }
 
   static establishAssociations() {
-    this.belongsTo(User, {
-      foreignKey: "userId",
-    })
+    this.belongsTo(User)
   }
 }
 

--- a/api/src/models/user-role.ts
+++ b/api/src/models/user-role.ts
@@ -44,7 +44,7 @@ export class UserRole extends Model<InferAttributes<UserRole>, InferCreationAttr
 
   static establishasAssociations() {
     this.belongsTo(User, {
-      foreignKey: "id",
+      foreignKey: "userId",
     })
   }
 }

--- a/api/src/models/user-role.ts
+++ b/api/src/models/user-role.ts
@@ -42,7 +42,7 @@ export class UserRole extends Model<InferAttributes<UserRole>, InferCreationAttr
     user: Association<UserRole, User>
   }
 
-  static establishasAssociations() {
+  static establishAssociations() {
     this.belongsTo(User, {
       foreignKey: "userId",
     })

--- a/api/src/models/user-role.ts
+++ b/api/src/models/user-role.ts
@@ -28,6 +28,8 @@ export class UserRole extends Model<InferAttributes<UserRole>, InferCreationAttr
   declare id: CreationOptional<number>
   declare userId: ForeignKey<User["id"]>
   declare role: string
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
 
   // https://sequelize.org/docs/v6/other-topics/typescript/#usage
   // https://sequelize.org/docs/v6/core-concepts/assocs/#special-methodsmixins-added-to-instances
@@ -70,11 +72,20 @@ UserRole.init(
         isIn: [Object.values(RoleTypes)],
       },
     },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
   },
   {
     sequelize,
     underscored: true,
-    timestamps: false,
   }
 )
 

--- a/api/src/models/user-role.ts
+++ b/api/src/models/user-role.ts
@@ -85,7 +85,6 @@ UserRole.init(
   },
   {
     sequelize,
-    underscored: true,
   }
 )
 

--- a/api/src/models/user-role.ts
+++ b/api/src/models/user-role.ts
@@ -61,7 +61,7 @@ UserRole.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        model: User,
+        model: "users",
         key: "id",
       },
     },

--- a/api/src/models/user.ts
+++ b/api/src/models/user.ts
@@ -59,7 +59,7 @@ export class User extends Model<InferAttributes<User>, InferCreationAttributes<U
     roles: Association<User, UserRole>
   }
 
-  static establishasAssociations() {
+  static establishAssociations() {
     this.hasMany(UserRole, {
       sourceKey: "id",
       foreignKey: "userId",

--- a/api/src/models/user.ts
+++ b/api/src/models/user.ts
@@ -125,7 +125,6 @@ User.init(
   },
   {
     sequelize,
-    underscored: true,
   }
 )
 

--- a/api/src/models/user.ts
+++ b/api/src/models/user.ts
@@ -37,7 +37,8 @@ export class User extends Model<InferAttributes<User>, InferCreationAttributes<U
   declare isAdmin: CreationOptional<boolean>
   declare ynetId: string | null
   declare directoryId: string | null
-  declare createDate: CreationOptional<Date>
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
 
   // https://sequelize.org/docs/v6/other-topics/typescript/#usage
   // https://sequelize.org/docs/v6/core-concepts/assocs/#foohasmanybar
@@ -111,7 +112,12 @@ User.init(
       type: DataTypes.STRING(50),
       allowNull: true,
     },
-    createDate: {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
@@ -120,7 +126,6 @@ User.init(
   {
     sequelize,
     underscored: true,
-    timestamps: false,
   }
 )
 

--- a/api/src/serializers/user-serializer.ts
+++ b/api/src/serializers/user-serializer.ts
@@ -19,7 +19,8 @@ export class UserSerializer extends BaseSerializer<User> {
       "isAdmin",
       "ynetId",
       "directoryId",
-      "createDate"
+      "createdAt",
+      "updatedAt"
     )
 
     defaultView.addField(

--- a/api/src/services/log-services.ts
+++ b/api/src/services/log-services.ts
@@ -29,7 +29,6 @@ export class LogServices extends BaseService {
         operation: `${operation} record with ${primaryKeyName}=${primaryKeyValue}`,
         tableName,
         data: JSON.stringify(model),
-        date: new Date(),
       },
       { transaction }
     )

--- a/api/tests/factories/centre-factories.ts
+++ b/api/tests/factories/centre-factories.ts
@@ -36,7 +36,7 @@ export const centreFactory = Factory.define<Centre>(({ sequence, onCreate }) => 
     hotMeal: faker.helpers.arrayElement([true, false, null]),
     licensedFor: faker.helpers.arrayElement([faker.number.int({ min: 1, max: 100 }), null]),
     lastSubmission: faker.helpers.arrayElement([faker.date.recent(), null]),
-    createDate: faker.date.past(),
+    createdAt: faker.date.past(),
   })
 })
 

--- a/api/tests/factories/user-factories.ts
+++ b/api/tests/factories/user-factories.ts
@@ -18,7 +18,7 @@ export const userFactory = Factory.define<User>(({ sequence, onCreate }) => {
       `Directory-${faker.number.int({ min: 1, max: 1000 })}`,
       null,
     ]),
-    createDate: faker.date.past(),
+    createdAt: faker.date.past(),
   })
 })
 


### PR DESCRIPTION
Fixes ELCC-5

# Context

In the interest of basic data tracking, I'm standardizing the database by adding a created_at, update_at column to each table in the database. Its a common pattern that makes debugging data quality issues and analytics much easier. In the future we may also want to go the "paranoid" route and add a "deleted_at" column as well.

# Implementation

Tweak the umzug migrator so migrations run in a transaction.
Make `underscores` and `timestamps` the default in all sequelize models.
Add timestamp columns to umzug `SequelizeMeta` table, but don't enable timestamps until migration has run in all environments.

# Testing Instructions

1. Boot the app via `dev up`

2. Check that the app complies, and that you can log in at http://localhost:8080.

3. Check that the migrations ran and that all tables now have `created_at` and `deleted_at` columns.
