### PR TITLE
ELCC-6: Standardize Database Table Naming Conventions

### DIFF
--- a/api/src/db/migrations/2023.09.29T00.19.54.pluralize-all-table-names.ts
+++ b/api/src/db/migrations/2023.09.29T00.19.54.pluralize-all-table-names.ts
@@ -1,0 +1,23 @@
+import type { Migration } from "@/db/umzug"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.renameTable("centre_funding_period", "centre_funding_periods")
+  await queryInterface.renameTable("funding_period", "funding_periods")
+  await queryInterface.renameTable("funding_submission_line_json", "funding_submission_line_jsons")
+  await queryInterface.renameTable(
+    "funding_submission_line_value",
+    "funding_submission_line_values"
+  )
+  await queryInterface.renameTable("funding_submission_line", "funding_submission_lines")
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.renameTable("centre_funding_periods", "centre_funding_period")
+  await queryInterface.renameTable("funding_periods", "funding_period")
+  await queryInterface.renameTable("funding_submission_line_jsons", "funding_submission_line_json")
+  await queryInterface.renameTable(
+    "funding_submission_line_values",
+    "funding_submission_line_value"
+  )
+  await queryInterface.renameTable("funding_submission_lines", "funding_submission_line")
+}

--- a/api/src/models/centre-funding-period.ts
+++ b/api/src/models/centre-funding-period.ts
@@ -85,7 +85,6 @@ CentreFundingPeriod.init(
   },
   {
     sequelize,
-    tableName: "centre_funding_period", // TODO: remove this once table name is pluralized
   }
 )
 

--- a/api/src/models/funding-submission-line-json.ts
+++ b/api/src/models/funding-submission-line-json.ts
@@ -103,7 +103,6 @@ FundingSubmissionLineJson.init(
   },
   {
     sequelize,
-    tableName: "funding_submission_line_json", // TODO: remove this once table name is pluralized
   }
 )
 

--- a/api/src/models/funding-submission-line-value.ts
+++ b/api/src/models/funding-submission-line-value.ts
@@ -86,7 +86,7 @@ FundingSubmissionLineValue.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
-        model: "funding_submission_line", // TODO: pluralize this once table name is pluralized
+        model: "funding_submission_lines",
         key: "id",
       },
     },
@@ -147,7 +147,6 @@ FundingSubmissionLineValue.init(
   },
   {
     sequelize,
-    tableName: "funding_submission_line_value", // TODO: remove this once table name is pluralized
   }
 )
 

--- a/api/src/models/funding-submission-line.ts
+++ b/api/src/models/funding-submission-line.ts
@@ -127,7 +127,6 @@ FundingSubmissionLine.init(
   },
   {
     sequelize,
-    tableName: "funding_submission_line", // TODO: remove this once table name is pluralized
   }
 )
 


### PR DESCRIPTION
Fixes ELCC-6

# Context

Standardize the centre_funding_period table name to the plural form centre_funding_periods so it matches the standard convention for table names.
Add a readme about this somewhere.
Investigate and fix any other tables with non-standard names.

Investigate if any columns have non-standard naming conventions and fix them as well.

# Testing Instructions

1. Boot the app via `dev up`

2. Check that the app complies, and that you can log in at http://localhost:8080.

3. Check that the migrations ran and that all table names are now pluralized.
