### PR TITLE
ELCC-17: Issue with Input Rounding Down, Affecting Operator Payments

### DIFF
--- a/Design/Entity Relationship Diagrams.wsd
+++ b/Design/Entity Relationship Diagrams.wsd
@@ -97,10 +97,10 @@ note right of "funding_submission_line_jsons"
     "sectionName": "Child Care Spaces",
     "lineName": "Infants",
     "monthlyAmount": 700,
-    "estChildCount": 1,
-    "actChildCount": 2,
-    "estComputedTotal": 700,
-    "actComputedTotal": 1400
+    "estimatedChildOccupancyRate": 1,
+    "actualChildOccupancyRate": 2,
+    "estimatedComputedTotal": 700,
+    "actualComputedTotal": 1400
   },
   ...
   ]

--- a/api/src/db/migrations/2023.10.02T17.49.08.clarify-meaning-of-child-count-properties.ts
+++ b/api/src/db/migrations/2023.10.02T17.49.08.clarify-meaning-of-child-count-properties.ts
@@ -1,0 +1,59 @@
+import { invert, mapKeys } from "lodash"
+
+import type { Migration } from "@/db/umzug"
+
+import { FundingSubmissionLineJson } from "@/models"
+import safeJsonParse from "@/db/utils/safe-parse-json"
+
+const OLD_TO_NEW_KEY_MAP: Readonly<Record<string, string>> = Object.freeze({
+  estChildCount: "estimatedChildOccupancyRate",
+  actChildCount: "actualChildOccupancyRate",
+  estComputedTotal: "estimatedComputedTotal",
+  actComputedTotal: "actualComputedTotal",
+})
+
+const NEW_TO_OLD_KEY_MAP: Readonly<Record<string, string>> = Object.freeze(
+  invert(OLD_TO_NEW_KEY_MAP)
+)
+
+export const up: Migration = async () => {
+  const fundingSubmissionLineJsons = await FundingSubmissionLineJson.findAll()
+  const promises = fundingSubmissionLineJsons.map(async (fundingSubmissionLineJson) => {
+    const values = fundingSubmissionLineJson.values
+    const lines = safeJsonParse(values)
+    const updatedLines = lines.map((line) => {
+      const lineWithUpdatedKeys = mapKeys(line, (_value, key) => {
+        if (key in OLD_TO_NEW_KEY_MAP) {
+          return OLD_TO_NEW_KEY_MAP[key]
+        } else {
+          return key
+        }
+      })
+      return lineWithUpdatedKeys
+    })
+    const stringifiedLines = JSON.stringify(updatedLines)
+    return fundingSubmissionLineJson.update({ values: stringifiedLines })
+  })
+  return Promise.all(promises)
+}
+
+export const down: Migration = async () => {
+  const fundingSubmissionLineJsons = await FundingSubmissionLineJson.findAll()
+  const promises = fundingSubmissionLineJsons.map(async (fundingSubmissionLineJson) => {
+    const values = fundingSubmissionLineJson.values
+    const lines = safeJsonParse(values)
+    const updatedLines = lines.map((line) => {
+      const lineWithUpdatedKeys = mapKeys(line, (_value, key) => {
+        if (key in NEW_TO_OLD_KEY_MAP) {
+          return NEW_TO_OLD_KEY_MAP[key]
+        } else {
+          return key
+        }
+      })
+      return lineWithUpdatedKeys
+    })
+    const stringifiedLines = JSON.stringify(updatedLines)
+    return fundingSubmissionLineJson.update({ values: stringifiedLines })
+  })
+  return Promise.all(promises)
+}

--- a/api/src/db/utils/safe-parse-json.ts
+++ b/api/src/db/utils/safe-parse-json.ts
@@ -1,0 +1,16 @@
+export function safeJsonParse(values: string): any[] {
+  try {
+    const lines = JSON.parse(values)
+    if (Array.isArray(lines)) {
+      return lines
+    } else {
+      console.error("Parsed value is not an array.")
+      return []
+    }
+  } catch (error) {
+    console.error("Error parsing JSON:", error)
+    return []
+  }
+}
+
+export default safeJsonParse

--- a/api/src/models/funding-line-value.ts
+++ b/api/src/models/funding-line-value.ts
@@ -1,4 +1,6 @@
-// TODO: Check if this should be added as a database model.
+// This is not a database model.
+// It describes the structure of the data in the funding_submission_line_json#values column.
+// In the future it might make sense to describe this via a JSON schema.
 export interface FundingLineValue {
   submissionLineId: number
   sectionName: string

--- a/api/src/models/funding-line-value.ts
+++ b/api/src/models/funding-line-value.ts
@@ -6,8 +6,8 @@ export interface FundingLineValue {
   sectionName: string
   lineName: string
   monthlyAmount: number
-  estChildCount: number
-  actChildCount: number
-  estComputedTotal: number
-  actComputedTotal: number
+  estimatedChildOccupancyRate: number
+  actualChildOccupancyRate: number
+  estimatedComputedTotal: number
+  actualComputedTotal: number
 }

--- a/api/src/models/funding-line-value.ts
+++ b/api/src/models/funding-line-value.ts
@@ -1,5 +1,4 @@
 // TODO: Check if this should be added as a database model.
-// TODO: camel case these after running the appropriate migration.
 export interface FundingLineValue {
   submissionLineId: number
   sectionName: string

--- a/api/src/models/funding-submission-line-json.ts
+++ b/api/src/models/funding-submission-line-json.ts
@@ -16,6 +16,7 @@ import sequelize from "@/db/db-client"
 
 import Centre from "@/models/centre"
 
+// TODO: consider renaming this to MonthlyWorksheet?
 export class FundingSubmissionLineJson extends Model<
   InferAttributes<FundingSubmissionLineJson>,
   InferCreationAttributes<FundingSubmissionLineJson>

--- a/api/src/services/funding-submission-line-json-services.ts
+++ b/api/src/services/funding-submission-line-json-services.ts
@@ -27,10 +27,10 @@ export class FundingSubmissionLineJsonServices implements BaseService {
         sectionName: line.sectionName,
         lineName: line.lineName,
         monthlyAmount: line.monthlyAmount,
-        estChildCount: 0,
-        actChildCount: 0,
-        estComputedTotal: 0,
-        actComputedTotal: 0,
+        estimatedChildOccupancyRate: 0,
+        actualChildOccupancyRate: 0,
+        estimatedComputedTotal: 0,
+        actualComputedTotal: 0,
       })
     }
 

--- a/api/src/services/funding-submission-line-json-services.ts
+++ b/api/src/services/funding-submission-line-json-services.ts
@@ -15,24 +15,23 @@ export class FundingSubmissionLineJsonServices implements BaseService {
       throw new Error("Fiscal year already exists for this centre")
     }
 
-    const basis = await FundingSubmissionLine.findAll({ where: { fiscalYear } })
+    const templateLines = await FundingSubmissionLine.findAll({ where: { fiscalYear } })
     const year = fiscalYear.split("/")[0]
     let date = moment.utc(`${year}-04-01`)
-    const lines = new Array<FundingLineValue>()
+    const lines: FundingLineValue[] = []
 
-    for (const line of basis) {
-      // TODO: Write a migration for existing data, and swap this to camel case.
+    templateLines.forEach((templateLine) => {
       lines.push({
-        submissionLineId: line.id as number,
-        sectionName: line.sectionName,
-        lineName: line.lineName,
-        monthlyAmount: line.monthlyAmount,
+        submissionLineId: templateLine.id,
+        sectionName: templateLine.sectionName,
+        lineName: templateLine.lineName,
+        monthlyAmount: templateLine.monthlyAmount,
         estimatedChildOccupancyRate: 0,
         actualChildOccupancyRate: 0,
         estimatedComputedTotal: 0,
         actualComputedTotal: 0,
       })
-    }
+    })
 
     const bulkAttributes = []
     for (let i = 0; i < 12; i++) {

--- a/web/src/modules/centre/components/MonthlyWorksheet.vue
+++ b/web/src/modules/centre/components/MonthlyWorksheet.vue
@@ -69,7 +69,7 @@
           </td>
           <td>
             <v-text-field
-              v-model="line.estChildCount"
+              v-model="line.estimatedChildOccupancyRate"
               density="compact"
               hide-details
               @change="changeLineAndPropagate(line, lineIndex, sectionIndex)"
@@ -77,7 +77,7 @@
           </td>
           <td>
             <v-text-field
-              :value="formatMoney(line.estComputedTotal)"
+              :value="formatMoney(line.estimatedComputedTotal)"
               density="compact"
               hide-details
               readonly
@@ -86,7 +86,7 @@
           </td>
           <td>
             <v-text-field
-              v-model="line.actChildCount"
+              v-model="line.actualChildOccupancyRate"
               density="compact"
               hide-details
               @change="changeLineAndPropagate(line, lineIndex, sectionIndex)"
@@ -95,7 +95,7 @@
 
           <td>
             <v-text-field
-              :value="formatMoney(line.actComputedTotal)"
+              :value="formatMoney(line.actualComputedTotal)"
               density="compact"
               hide-details
               readonly
@@ -109,7 +109,10 @@
           <td>
             <v-text-field
               :value="
-                section.lines.reduce((a: number, v: any) => a + parseFloat(v.estChildCount || 0), 0)
+                section.lines.reduce(
+                  (a: number, v: any) => a + parseFloat(v.estimatedChildOccupancyRate || 0),
+                  0
+                )
               "
               density="compact"
               hide-details
@@ -122,7 +125,7 @@
               :value="
                 formatMoney(
                   section.lines.reduce(
-                    (a: number, v: any) => a + parseFloat(v.estComputedTotal || 0),
+                    (a: number, v: any) => a + parseFloat(v.estimatedComputedTotal || 0),
                     0
                   )
                 )
@@ -136,7 +139,10 @@
           <td>
             <v-text-field
               :value="
-                section.lines.reduce((a: number, v: any) => a + parseFloat(v.actChildCount || 0), 0)
+                section.lines.reduce(
+                  (a: number, v: any) => a + parseFloat(v.actualChildOccupancyRate || 0),
+                  0
+                )
               "
               density="compact"
               hide-details
@@ -149,7 +155,7 @@
               :value="
                 formatMoney(
                   section.lines.reduce(
-                    (a: number, v: any) => a + parseFloat(v.actComputedTotal || 0),
+                    (a: number, v: any) => a + parseFloat(v.actualComputedTotal || 0),
                     0
                   )
                 )
@@ -186,27 +192,27 @@ export default {
     ...mapActions(useCentreStore, ["saveWorksheet", "duplicateAprilEstimates"]),
     formatMoney,
     changeLineAndPropagate(line: any, lineIndex: number, sectionIndex: number) {
-      line.estChildCount = parseFloat(line.estChildCount || 0)
-      line.actChildCount = parseFloat(line.actChildCount || 0)
+      line.estimatedChildOccupancyRate = parseFloat(line.estimatedChildOccupancyRate || 0)
+      line.actualChildOccupancyRate = parseFloat(line.actualChildOccupancyRate || 0)
       this.refreshLineTotals(line)
 
       // Bind section 1 to sections 2 and 3
       // When you update the values in section 1, it will propagated the values to section 2 and 3
       if (sectionIndex === 0) {
         const section1Line = this.sections[1].lines[lineIndex]
-        section1Line.estChildCount = line.estChildCount
-        section1Line.actChildCount = line.actChildCount
+        section1Line.estimatedChildOccupancyRate = line.estimatedChildOccupancyRate
+        section1Line.actualChildOccupancyRate = line.actualChildOccupancyRate
         this.refreshLineTotals(section1Line)
 
         const section2Line = this.sections[2].lines[lineIndex]
-        section2Line.estChildCount = line.estChildCount
-        section2Line.actChildCount = line.actChildCount
+        section2Line.estimatedChildOccupancyRate = line.estimatedChildOccupancyRate
+        section2Line.actualChildOccupancyRate = line.actualChildOccupancyRate
         this.refreshLineTotals(section2Line)
       }
     },
     refreshLineTotals(line: any) {
-      line.estComputedTotal = line.monthlyAmount * line.estChildCount
-      line.actComputedTotal = line.monthlyAmount * line.actChildCount
+      line.estimatedComputedTotal = line.monthlyAmount * line.estimatedChildOccupancyRate
+      line.actualComputedTotal = line.monthlyAmount * line.actualChildOccupancyRate
     },
     async saveClick() {
       await this.saveWorksheet(this.month)

--- a/web/src/modules/centre/components/MonthlyWorksheet.vue
+++ b/web/src/modules/centre/components/MonthlyWorksheet.vue
@@ -109,7 +109,7 @@
           <td>
             <v-text-field
               :value="
-                section.lines.reduce((a: number, v: any) => a + parseInt(v.estChildCount || 0), 0)
+                section.lines.reduce((a: number, v: any) => a + parseFloat(v.estChildCount || 0), 0)
               "
               density="compact"
               hide-details
@@ -136,7 +136,7 @@
           <td>
             <v-text-field
               :value="
-                section.lines.reduce((a: number, v: any) => a + parseInt(v.actChildCount || 0), 0)
+                section.lines.reduce((a: number, v: any) => a + parseFloat(v.actChildCount || 0), 0)
               "
               density="compact"
               hide-details
@@ -186,8 +186,8 @@ export default {
     ...mapActions(useCentreStore, ["saveWorksheet", "duplicateAprilEstimates"]),
     formatMoney,
     changeLineAndPropagate(line: any, lineIndex: number, sectionIndex: number) {
-      line.estChildCount = parseInt(line.estChildCount || 0)
-      line.actChildCount = parseInt(line.actChildCount || 0)
+      line.estChildCount = parseFloat(line.estChildCount || 0)
+      line.actChildCount = parseFloat(line.actChildCount || 0)
       this.refreshLineTotals(line)
 
       // Bind section 1 to sections 2 and 3

--- a/web/src/modules/centre/components/PaymentSummary.vue
+++ b/web/src/modules/centre/components/PaymentSummary.vue
@@ -132,7 +132,7 @@
 </template>
 <script lang="ts">
 export default {
-  name: "MonthlyWorksheet",
+  name: "PaymentSummary",
   props: ["month"],
   setup() {},
 }

--- a/web/src/modules/centre/components/WorksheetSummary.vue
+++ b/web/src/modules/centre/components/WorksheetSummary.vue
@@ -18,8 +18,8 @@
         <td>
           {{ line.month }}
         </td>
-        <td class="text-right">{{ formatMoney(line.estComputedTotal) }}</td>
-        <td class="text-right">{{ formatMoney(line.actComputedTotal) }}</td>
+        <td class="text-right">{{ formatMoney(line.estimatedComputedTotal) }}</td>
+        <td class="text-right">{{ formatMoney(line.actualComputedTotal) }}</td>
         <td class="text-right">{{ formatMoney(line.diff) }}</td>
       </tr>
 
@@ -31,7 +31,7 @@
               yearWorksheets
                 .flatMap((y: any) => y.sections)
                 .flatMap((s) => s.lines)
-                .reduce((a: number, v: any) => a + parseFloat(v.estComputedTotal), 0)
+                .reduce((a: number, v: any) => a + parseFloat(v.estimatedComputedTotal), 0)
             )
           }}
         </td>
@@ -42,7 +42,7 @@
               yearWorksheets
                 .flatMap((y: any) => y.sections)
                 .flatMap((s) => s.lines)
-                .reduce((a: number, v: any) => a + parseFloat(v.actComputedTotal), 0)
+                .reduce((a: number, v: any) => a + parseFloat(v.actualComputedTotal), 0)
             )
           }}
         </td>
@@ -215,79 +215,79 @@ export default {
     },
     summaryLines() {
       const lines = []
-      let runningEstComputedTotal = 0
-      let runningActComputedTotal = 0
+      let runningestimatedComputedTotal = 0
+      let runningactualComputedTotal = 0
 
       for (const line of this.yearWorksheets) {
         const rows = line.sections.flatMap((y: any) => y).flatMap((s: any) => s.lines)
 
         /* let v1 = line.flatMap((y: any) => y.sections)
                 .flatMap((s:any) => s.lines)
-                .reduce((a: number, v: any) => a + parseFloat(v.actChildCount), 0) */
+                .reduce((a: number, v: any) => a + parseFloat(v.actualChildOccupancyRate), 0) */
 
         // console.log(v1);
         const monthVal = {
           month: line.month,
-          estComputedTotal: rows.reduce(
-            (a: number, v: any) => a + parseFloat(v.estComputedTotal),
+          estimatedComputedTotal: rows.reduce(
+            (a: number, v: any) => a + parseFloat(v.estimatedComputedTotal),
             0
           ),
-          actComputedTotal: rows.reduce(
-            (a: number, v: any) => a + parseFloat(v.actComputedTotal),
+          actualComputedTotal: rows.reduce(
+            (a: number, v: any) => a + parseFloat(v.actualComputedTotal),
             0
           ),
           diff: 0,
         }
 
-        monthVal.diff = monthVal.estComputedTotal - monthVal.actComputedTotal
+        monthVal.diff = monthVal.estimatedComputedTotal - monthVal.actualComputedTotal
 
         lines.push(monthVal)
 
-        runningEstComputedTotal += monthVal.estComputedTotal
-        runningActComputedTotal += monthVal.actComputedTotal
+        runningestimatedComputedTotal += monthVal.estimatedComputedTotal
+        runningactualComputedTotal += monthVal.actualComputedTotal
 
-        console.log(runningEstComputedTotal, monthVal.estComputedTotal)
+        console.log(runningestimatedComputedTotal, monthVal.estimatedComputedTotal)
 
         if (line.month == "June") {
           lines.push({
             month: "Initial Advance (3 mos)",
-            estComputedTotal: runningEstComputedTotal,
-            actComputedTotal: runningActComputedTotal,
-            diff: runningEstComputedTotal - runningActComputedTotal,
+            estimatedComputedTotal: runningestimatedComputedTotal,
+            actualComputedTotal: runningactualComputedTotal,
+            diff: runningestimatedComputedTotal - runningactualComputedTotal,
           })
-          runningEstComputedTotal = runningActComputedTotal = 0
+          runningestimatedComputedTotal = runningactualComputedTotal = 0
         } else if (line.month == "August") {
           lines.push({
             month: "Second Advance (2 mos) ",
-            estComputedTotal: runningEstComputedTotal,
-            actComputedTotal: runningActComputedTotal,
-            diff: runningEstComputedTotal - runningActComputedTotal,
+            estimatedComputedTotal: runningestimatedComputedTotal,
+            actualComputedTotal: runningactualComputedTotal,
+            diff: runningestimatedComputedTotal - runningactualComputedTotal,
           })
-          runningEstComputedTotal = runningActComputedTotal = 0
+          runningestimatedComputedTotal = runningactualComputedTotal = 0
         } else if (line.month == "October") {
           lines.push({
             month: "Third Advance (2 mos) ",
-            estComputedTotal: runningEstComputedTotal,
-            actComputedTotal: runningActComputedTotal,
-            diff: runningEstComputedTotal - runningActComputedTotal,
+            estimatedComputedTotal: runningestimatedComputedTotal,
+            actualComputedTotal: runningactualComputedTotal,
+            diff: runningestimatedComputedTotal - runningactualComputedTotal,
           })
-          runningEstComputedTotal = runningActComputedTotal = 0
+          runningestimatedComputedTotal = runningactualComputedTotal = 0
         } else if (line.month == "December") {
           lines.push({
             month: "Fourth Advance (2 mos) ",
-            estComputedTotal: runningEstComputedTotal,
-            actComputedTotal: runningActComputedTotal,
-            diff: runningEstComputedTotal - runningActComputedTotal,
+            estimatedComputedTotal: runningestimatedComputedTotal,
+            actualComputedTotal: runningactualComputedTotal,
+            diff: runningestimatedComputedTotal - runningactualComputedTotal,
           })
-          runningEstComputedTotal = runningActComputedTotal = 0
+          runningestimatedComputedTotal = runningactualComputedTotal = 0
         } else if (line.month == "February") {
           lines.push({
             month: "Fifth Advance (2 mos) ",
-            estComputedTotal: runningEstComputedTotal,
-            actComputedTotal: runningActComputedTotal,
-            diff: runningEstComputedTotal - runningActComputedTotal,
+            estimatedComputedTotal: runningestimatedComputedTotal,
+            actualComputedTotal: runningactualComputedTotal,
+            diff: runningestimatedComputedTotal - runningactualComputedTotal,
           })
-          runningEstComputedTotal = runningActComputedTotal = 0
+          runningestimatedComputedTotal = runningactualComputedTotal = 0
         }
       }
 

--- a/web/src/modules/centre/store/index.ts
+++ b/web/src/modules/centre/store/index.ts
@@ -196,8 +196,8 @@ export const useCentreStore = defineStore("centre", {
             const aprilLine = aprilLines.filter(
               (a: any) => a.submissionLineId == line.submissionLineId
             )
-            line.estChildCount = aprilLine[0].estChildCount
-            line.estComputedTotal = aprilLine[0].estComputedTotal
+            line.estimatedChildOccupancyRate = aprilLine[0].estimatedChildOccupancyRate
+            line.estimatedComputedTotal = aprilLine[0].estimatedComputedTotal
           }
         }
         await this.saveWorksheet(month, false)

--- a/web/src/modules/centre/store/index.ts
+++ b/web/src/modules/centre/store/index.ts
@@ -20,7 +20,7 @@ interface CentreState {
 
 export const useCentreStore = defineStore("centre", {
   state: (): CentreState => ({
-    centres: new Array<ChildCareCentre>(),
+    centres: [],
     selectedCentre: undefined,
     editingCentre: undefined,
     isLoading: false,
@@ -62,16 +62,15 @@ export const useCentreStore = defineStore("centre", {
       this.selectedCentre = centre
     },
     selectCentreById(id: number) {
-      if (this.isLoading || this.centres.length == 0) {
-        const self = this
-
+      if (this.isLoading && this.centres.length == 0) {
         const handle = window.setInterval(() => {
-          if (self.isLoading || this.centres.length == 0) {
-          } else {
-            window.clearInterval(handle)
-            this.selectedCentre = this.centres.filter((c) => c.id == id)[0]
+          if (this.isLoading && this.centres.length == 0) {
+            return // wait some more
           }
-        }, 100)
+
+          window.clearInterval(handle)
+          this.selectedCentre = this.centres.filter((c) => c.id == id)[0]
+        }, 300)
       } else {
         this.selectedCentre = this.centres.filter((c) => c.id == id)[0]
       }

--- a/web/src/modules/submission-lines/components/SubmissionLineEditor.vue
+++ b/web/src/modules/submission-lines/components/SubmissionLineEditor.vue
@@ -84,7 +84,7 @@ import { mapActions, mapState } from "pinia"
 import { useSubmissionLinesStore } from "../store"
 
 export default {
-  name: "UserEditor",
+  name: "SubmissionLineEditor",
   data: () => ({}),
   computed: {
     ...mapState(useSubmissionLinesStore, ["selectedLine"]),

--- a/web/src/modules/submission-lines/views/SubmissionLinesList.vue
+++ b/web/src/modules/submission-lines/views/SubmissionLinesList.vue
@@ -68,9 +68,9 @@
     ></v-data-table>
   </base-card>
 
-  <submission-line-editor></submission-line-editor>
+  <SubmissionLineEditor />
 
-  <funding-fiscal-editor></funding-fiscal-editor>
+  <FundingFiscalEditor />
 </template>
 <script lang="ts">
 import { mapActions, mapState } from "pinia"

--- a/web/src/store/UserStore.ts
+++ b/web/src/store/UserStore.ts
@@ -67,7 +67,7 @@ export const useUserStore = defineStore("user", {
     async loadCurrentUser() {
       const api = useApiStore()
       await api.secureCall("get", PROFILE_URL).then((resp) => {
-        this.user = resp.data
+        this.user = resp.data || {}
         this.user.roles = []
       })
     },


### PR DESCRIPTION
Fixes ELCC-17

# Context

I noticed everything I enter rounds down to the nearest whole number.  We definitely need to be able to enter 2 decimal places because rounding down gives the operators less money than they are entitled to.

1. Spaces are sometimes (for example) 2.4 children, as there are 2 full time spots taken, and 1 child that only comes 2 days per week (or some other version of part time).
2. Building Expenses are reported with cents, and then we multiply that by 37% (or 43% in the communities).
3. Wage Enhancement hours are sometimes reported with decimals.  (While filling in this section, I just input the total hours from each Level just so there was something to test.)

# Implementation

1. Remap funding submission line keys to increase clarity
```js
{
  estChildCount: "estimatedChildOccupancyRate",
  actChildCount: "actualChildOccupancyRate",
  estComputedTotal: "estimatedComputedTotal",
  actComputedTotal: "actualComputedTotal",
}
```

child count isn't a number of children, it is an occupancy rate value.
Switched from parsing the value as an integer to parsing it as a float.

# Screenshots

(if making UI changes add screenshots comparing the old and new experience)

# Testing Instructions

1. Boot the app via `dev up`
2. Check that the app complies, and that you can log in at http://localhost:8080.
3. Go to http://localhost:8080/child-care-centres.
4. Select the first child care center, then click the "view details" button in the far right panel.
5. Select the "Worksheets" tab.
6. Scroll down to the "Building Expenses" section.
7. Enter a decimal value 1.6 for the first fields.
8. Check that the total calculation does not lose precision when rounding. At least not more than a cent. It is possible that some precision is lost as we aren't using a financial library to perform these calculations; however, I'm leaving that level of precision till another day.
