### PR TITLE
Fixup: Only Run Database Initializers in Development

### DIFF
--- a/api/src/initializers/05-wait-for-database.ts
+++ b/api/src/initializers/05-wait-for-database.ts
@@ -1,23 +1,12 @@
-import { DB_HOST, DB_PASS, DB_PORT, NODE_ENV } from "@/config"
+import { DB_HOST, DB_NAME, DB_PASS, DB_PORT, DB_USER, NODE_ENV } from "@/config"
 import { Sequelize } from "sequelize"
-
-const db = new Sequelize({
-  dialect: "mssql",
-  username: "sa", // default user that should always exist
-  database: "master", // default database that should always exist
-  password: DB_PASS,
-  host: DB_HOST,
-  port: DB_PORT,
-  schema: "dbo",
-  logging: NODE_ENV === "development" ? console.log : false,
-})
 
 const INTERVAL_SECONDS = 5
 const TIMEOUT_SECONDS = 5
 const RETRIES = 3
 const START_PERIOD_SECONDS = 10
 
-function checkHealth(timeoutSeconds: number) {
+function checkHealth(db: Sequelize, timeoutSeconds: number) {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error("Connection timeout")), timeoutSeconds * 1000)
     db.authenticate()
@@ -44,11 +33,32 @@ export async function waitForDatabase({
   retries?: number
   startPeriodSeconds?: number
 } = {}): Promise<void> {
+  let username: string
+  let database: string
+  if (NODE_ENV === "production") {
+    username = DB_USER
+    database = DB_NAME
+  } else {
+    username = "sa" // default user that should always exist
+    database = "master" // default database that should always exist
+  }
+
+  const db = new Sequelize({
+    dialect: "mssql",
+    username,
+    database,
+    password: DB_PASS,
+    host: DB_HOST,
+    port: DB_PORT,
+    schema: "dbo",
+    logging: NODE_ENV === "development" ? console.log : false,
+  })
+
   await sleep(startPeriodSeconds)
 
   for (let i = 0; i < retries; i++) {
     try {
-      await checkHealth(timeoutSeconds)
+      await checkHealth(db, timeoutSeconds)
       console.log("Database connection successful.")
       return
     } catch (error) {

--- a/api/src/initializers/05-wait-for-database.ts
+++ b/api/src/initializers/05-wait-for-database.ts
@@ -35,7 +35,13 @@ export async function waitForDatabase({
 } = {}): Promise<void> {
   let username: string
   let database: string
-  if (NODE_ENV === "production") {
+  if (
+    NODE_ENV === "production" &&
+    process.env.PRODUCTION_DATABASE_SA_MASTER_CREDS_AVAILABLE !== "true"
+  ) {
+    console.info(
+      "Falling back to local database credentials because production database sa:master credentials are not available."
+    )
     username = DB_USER
     database = DB_NAME
   } else {

--- a/api/src/initializers/10-create-database.ts
+++ b/api/src/initializers/10-create-database.ts
@@ -11,8 +11,13 @@ async function databaseExists(db: Sequelize, databaseName: string): Promise<bool
 }
 
 async function createDatabase(): Promise<void> {
-  if (NODE_ENV === "production") {
-    console.info("Skipping database creation initializer in production")
+  if (
+    NODE_ENV === "production" &&
+    process.env.PRODUCTION_DATABASE_SA_MASTER_CREDS_AVAILABLE !== "true"
+  ) {
+    console.info(
+      "Skipping database creation initializer because production database sa:master credentials are not available."
+    )
     return
   }
 

--- a/api/src/initializers/10-create-database.ts
+++ b/api/src/initializers/10-create-database.ts
@@ -1,18 +1,7 @@
 import { DB_NAME, DB_HOST, DB_PASS, DB_PORT, NODE_ENV } from "@/config"
 import { QueryTypes, Sequelize } from "sequelize"
 
-const db = new Sequelize({
-  dialect: "mssql",
-  username: "sa", // default user that should always exist
-  database: "master", // default database that should always exist
-  password: DB_PASS,
-  host: DB_HOST,
-  port: DB_PORT,
-  schema: "dbo",
-  logging: NODE_ENV === "development" ? console.log : false,
-})
-
-async function databaseExists(databaseName: string): Promise<boolean> {
+async function databaseExists(db: Sequelize, databaseName: string): Promise<boolean> {
   const result = await db.query("SELECT 1 FROM sys.databases WHERE name = ?", {
     type: QueryTypes.SELECT,
     replacements: [databaseName],
@@ -22,7 +11,23 @@ async function databaseExists(databaseName: string): Promise<boolean> {
 }
 
 async function createDatabase(): Promise<void> {
-  if (await databaseExists(DB_NAME)) return
+  if (NODE_ENV === "production") {
+    console.info("Skipping database creation initializer in production")
+    return
+  }
+
+  const db = new Sequelize({
+    dialect: "mssql",
+    username: "sa", // default user that should always exist
+    database: "master", // default database that should always exist
+    password: DB_PASS,
+    host: DB_HOST,
+    port: DB_PORT,
+    schema: "dbo",
+    logging: NODE_ENV === "development" ? console.log : false,
+  })
+
+  if (await databaseExists(db, DB_NAME)) return
 
   console.log(`Database ${DB_NAME} does not exist: creating...`)
   await db.query(`CREATE DATABASE ${DB_NAME}`, { raw: true }).catch((error) => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     restart: unless-stopped
     environment:
       NODE_ENV: production
+      PRODUCTION_DATABASE_SA_MASTER_CREDS_AVAILABLE: "true"
     env_file:
       - .env
     ports:


### PR DESCRIPTION
Relates to:

- https://github.com/icefoganalytics/elcc-data-management/pull/56

# Context

Current initializer pipeline fails in production.
This is because we don't have access to the `sa` user, so we have to simply trust that the environment is set up correctly.

# Implementation

Have the "wait for database" initializer use the standard database creds instead of master creds.
Skip the "create database" initializer in production.

# Testing Instructions

1. Boot the app via `dev up`
2. Check that the app complies, and that you can log in at http://localhost:8080.
3. Check that the local production build works correctly via `docker compose up --build`.
4. Then check that you can log in at http://localhost:8080
5. Comment out the `PRODUCTION_DATABASE_SA_MASTER_CREDS_AVAILABLE` flag in the production `docker-compose.yaml` and re-build the app.
6. Check that it skips the first 2 initializers.
