### PR TITLE
Fix UI Glitch Where Currency Type Is Appearing in Currency Input Fields

### DIFF
--- a/api/src/utils/formatter.ts
+++ b/api/src/utils/formatter.ts
@@ -1,11 +1,16 @@
 export function formatDollar(
   input: number | undefined,
-  locales: string | string[] | undefined = "en-US",
-  options: Intl.NumberFormatOptions = {}
+  options: Intl.NumberFormatOptions & {
+    locales?: string | string[] | undefined
+  } = {}
 ) {
+  const locales = options.locales || "en-CA"
+  delete options.locales
+
   const formatter = new Intl.NumberFormat(locales, {
     style: "currency",
-    currency: "USD",
+    currency: "CAD",
+    currencyDisplay: "symbol",
     ...options,
     // These options are needed to round to whole numbers if that's what you want.
     //minimumFractionDigits: 0, // (this suffices for whole numbers, but will print 2500.10 as $2,500.1)

--- a/web/src/components/CurrencyInput.vue
+++ b/web/src/components/CurrencyInput.vue
@@ -20,7 +20,9 @@ const props = defineProps({
   options: {
     type: Object,
     default: () => ({
-      currency: "USD",
+      currency: "CAD",
+      locale: "en-CA",
+      currencyDisplay: "symbol",
       precision: 2,
       // accountingSign: true,
       hideCurrencySymbolOnFocus: false,

--- a/web/src/utils/format-money.ts
+++ b/web/src/utils/format-money.ts
@@ -8,12 +8,17 @@ export function dollarsToCents(value: number) {
 
 export function formatMoney(
   input: number | undefined,
-  locales: string | string[] | undefined = "en-US",
-  options: Intl.NumberFormatOptions = {}
+  options: Intl.NumberFormatOptions & {
+    locales?: string | string[] | undefined
+  } = {}
 ) {
+  const locales = options.locales || "en-CA"
+  delete options.locales
+
   const formatter = new Intl.NumberFormat(locales, {
     style: "currency",
-    currency: "USD",
+    currency: "CAD",
+    currencyDisplay: "symbol",
     ...options,
     // These options are needed to round to whole numbers if that's what you want.
     //minimumFractionDigits: 0, // (this suffices for whole numbers, but will print 2500.10 as $2,500.1)


### PR DESCRIPTION
Fixes https://yg-hpw.atlassian.net/browse/ELCC-39

# Context

On the child care center detail view Employees tab http://localhost:8080/child-care-centres/1/2023-24/employees/april the currency type is showing up in the currency input fields on some systems. This might be cause by an individual user’s locale settings.

Example of broken UI
![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/3429ec90-cfc7-4463-9c42-838b0c2d97d7)

Bug exists in web/src/components/CurrencyInput.vue -> vue-currency-input which is using Intl.NumberFormat

It says "US" in the code, setting it to CAD might fix the issue.

# Implementation

Harmonize all Intl currency formatters to use CAD and en-CA.
Tried setting a couple of locales, but could not re-produce locally, opting for a guess and check approach.

# Screenshots

What UI Should Look Like (no currency type displayed at all)
![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/828234a7-c112-4e93-8f96-359aca02e9c2)

# Testing Instructions

1. Boot the app via `dev up`
2. Check that the app complies, and that you can log in at http://localhost:8080.
3. From the /dashboard page, click on the “Education is Currently Funding” card.
4. Click on a child care centre from the list to open the details panel on the right hand side of the page.
5. Click the “view details” button in the bottom right hand corner of the page.
6. From the detailed child care centre view, select the Employees tab.
7. Enter some data in the Employee Benefits section and click Save.
> I haven’t been able to recreate the bug locally. But this is probably related to the end user’s locale/language settings in their browser.
