### PR TITLE
ELCC-40: Fix Employee Benefits Section Total Calculation

### DIFF
--- a/web/src/components/CurrencyInput.vue
+++ b/web/src/components/CurrencyInput.vue
@@ -1,39 +1,30 @@
 <template>
-  <!--
-    Supress default update:model-value emit, then triggers on blur instead
-    This fixes the annoying cursor jump to end bug
-  -->
   <v-text-field
     ref="inputRef"
-    :model-value="modelValue"
     type="text"
     @blur="onBlur"
-    @update:model-value="false"
   />
 </template>
 
 <script setup lang="ts">
-import { useCurrencyInput, type CurrencyInputOptions } from "vue-currency-input"
+import { useCurrencyInput, type CurrencyInputOptions, CurrencyDisplay } from "vue-currency-input"
 
-const props = defineProps({
-  modelValue: Number,
-  options: {
-    type: Object,
-    default: () => ({
-      currency: "CAD",
-      locale: "en-CA",
-      currencyDisplay: "symbol",
-      precision: 2,
-      // accountingSign: true,
-      hideCurrencySymbolOnFocus: false,
-    }),
-  },
+const props = defineProps<{
+  modelValue: number | null
+  options?: Partial<CurrencyInputOptions>
+}>()
+
+const emit = defineEmits(["update:modelValue", "change"])
+
+const { inputRef, numberValue } = useCurrencyInput({
+  currency: "CAD",
+  locale: "en-CA",
+  currencyDisplay: CurrencyDisplay.symbol,
+  precision: 2,
+  // accountingSign: true,
+  hideCurrencySymbolOnFocus: false,
+  ...props.options,
 })
-
-const emit = defineEmits(["update:modelValue"])
-
-const autoEmit = false
-const { inputRef, numberValue } = useCurrencyInput(props.options as CurrencyInputOptions, autoEmit)
 
 function onBlur() {
   emit("update:modelValue", numberValue.value)

--- a/web/src/modules/centre/components/EditEmployeeBenefitWidget.vue
+++ b/web/src/modules/centre/components/EditEmployeeBenefitWidget.vue
@@ -148,8 +148,8 @@
         </td>
       </tr>
       <tr>
-        <td class="text-uppercase d-flex align-center">
-          Section Total
+        <td class="d-flex align-center">
+          Total Cost
           <v-tooltip bottom>
             <template #activator="{ props }">
               <v-icon
@@ -158,16 +158,13 @@
                 >mdi-help-circle-outline</v-icon
               >
             </template>
-            <span class="text-white">
-              Totaling the lesser of either {{ costCapPercentage }}% of Gross Payroll or Employee
-              Cost plus Employer Cost
-            </span>
+            <span class="text-white"> Totaling the sum of Employee Cost plus Employer Cost </span>
           </v-tooltip>
         </td>
         <td>
           <v-text-field
-            :model-value="formatMoney(minimumTotalCostEstimated)"
-            aria-label="Minimum Total Cost Estimated"
+            :model-value="formatMoney(totalCostEstimated)"
+            aria-label="Total Cost Estimated"
             color="primary"
             density="compact"
             tabindex="-1"
@@ -179,8 +176,51 @@
         <td></td>
         <td>
           <v-text-field
-            :model-value="formatMoney(minimumTotalCostActual)"
-            aria-label="Minimum Total Cost Actual"
+            :model-value="formatMoney(totalCostActual)"
+            aria-label="Total Cost Actual"
+            color="primary"
+            density="compact"
+            tabindex="-1"
+            variant="plain"
+            hide-details
+            readonly
+          />
+        </td>
+      </tr>
+      <tr>
+        <td class="text-uppercase d-flex align-center">
+          Paid Amount
+          <v-tooltip bottom>
+            <template #activator="{ props }">
+              <v-icon
+                class="ml-1"
+                v-bind="props"
+                >mdi-help-circle-outline</v-icon
+              >
+            </template>
+            <span class="text-white">
+              Totaling the lesser of either {{ costCapPercentage }}% of Gross Payroll or Employer
+              Cost
+            </span>
+          </v-tooltip>
+        </td>
+        <td>
+          <v-text-field
+            :model-value="formatMoney(minimumPaidAmountEstimated)"
+            aria-label="Minimum Paid Amount Estimated"
+            color="primary"
+            density="compact"
+            tabindex="-1"
+            variant="plain"
+            hide-details
+            readonly
+          />
+        </td>
+        <td></td>
+        <td>
+          <v-text-field
+            :model-value="formatMoney(minimumPaidAmountActual)"
+            aria-label="Minimum Paid Amount Actual"
             color="primary"
             density="compact"
             tabindex="-1"
@@ -267,21 +307,25 @@ const monthlyBenefitCostCapActual = computed(() => {
 
   return employeeBenefit.value.grossPayrollMonthlyActual * employeeBenefit.value.costCapPercentage
 })
-const minimumTotalCostEstimated = computed(() => {
+const totalCostEstimated = computed(() => {
   if (isUndefined(employeeBenefit.value)) return 0
 
-  return Math.min(
-    employeeBenefit.value.employeeCostEstimated + employeeBenefit.value.employerCostEstimated,
-    monthlyBenefitCostCapEstimated.value
-  )
+  return employeeBenefit.value.employeeCostEstimated + employeeBenefit.value.employerCostEstimated
 })
-const minimumTotalCostActual = computed(() => {
+const totalCostActual = computed(() => {
   if (isUndefined(employeeBenefit.value)) return 0
 
-  return Math.min(
-    employeeBenefit.value.employeeCostActual + employeeBenefit.value.employerCostActual,
-    monthlyBenefitCostCapActual.value
-  )
+  return employeeBenefit.value.employeeCostActual + employeeBenefit.value.employerCostActual
+})
+const minimumPaidAmountEstimated = computed(() => {
+  if (isUndefined(employeeBenefit.value)) return 0
+
+  return Math.min(employeeBenefit.value.employerCostEstimated, monthlyBenefitCostCapEstimated.value)
+})
+const minimumPaidAmountActual = computed(() => {
+  if (isUndefined(employeeBenefit.value)) return 0
+
+  return Math.min(employeeBenefit.value.employerCostActual, monthlyBenefitCostCapActual.value)
 })
 
 function buildEmployeeBenefit(attributes: Partial<EmployeeBenefit>): NonPersistedEmployeeBenefit {


### PR DESCRIPTION
Fixes https://yg-hpw.atlassian.net/browse/ELCC-40

Relates to:
- https://github.com/icefoganalytics/elcc-data-management/commit/ab400487f7c78f3b5561f055a97b55a9897a5fe8

# Context

Employee benefits section isn’t using the correct calculation for section total. There are, in fact, two section totals required. On that sums the employee + employer cost, and one that is the min of the employer cost and 8% of gross payroll.

Example of UI with incorrect calculation
![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/e1ae5380-1cfa-4f5e-8aec-c3260eda14de)

## Proposed Solution

> replace the "SECTION TOTAL" with "Total Cost" which is employee + employer, then add one more field below called "Paid Amount" which is the Min(Employer, 8%)

# Implementation

Break paid amount out of total cost and fix calculation. Employee cost was not supposed to be part of the minimum paid amount calculation.

# Screenshots

New UI with update calculation and "PAID AMOUNT" field
http://localhost:8080/child-care-centres/1/2023-24/employees/april
![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/91aa03f5-68d0-4dce-bd9c-e6d646fd54b5)

# Testing Instructions

1. Boot the app via `dev up`
2. Check that the app complies, and that you can log in at http://localhost:8080.
3. From the /dashboard page, click on the “Education is Currently Funding” card.
4. Click on a child care centre from the list to open the details panel on the right hand side of the page.
5. Click the “view details” button in the bottom right hand corner of the page.
6. From the detailed child care centre view, select the Employees tab. URL should look something like http://localhost:8080/child-care-centres/1/2023-24/employees/april
7. Enter values in all the Employee Benefits fields, note that “Section Total” reflects the minimum of Employee cost + Employer cost and 8% of Gross Payroll. This is incorrect, minimum should not include Employee cost. As such, a section total line is required.
8. After entering some data in the April tab, and saving it.
9. Switch to the May tab, then back to the April tab, check that the formatting on the totals is not lost by this switch.
10. Next go to the Summary -> Payments tab.
11. Add a new payment and then edit the value. Check that the cursor does not jump around strangely as you are editing.
