### PR TITLE
:beetle: 

### DIFF
--- a/api/src/models/payment.ts
+++ b/api/src/models/payment.ts
@@ -21,7 +21,7 @@ export class Payment extends Model<InferAttributes<Payment>, InferCreationAttrib
   declare id: CreationOptional<number>
   declare centreId: ForeignKey<Centre["id"]>
   declare fiscalYear: string
-  declare paidOn: Date
+  declare paidOn: string
   declare amountInCents: number
   declare name: string
   declare createdAt: CreationOptional<Date>


### PR DESCRIPTION
Fixes https://yg-hpw.atlassian.net/browse/ELCC-44

# Context

Use report
> when putting in the payment dates, the system puts it back a day when you save.

## Likely Steps to Reproduce

Haven’t recreated this locally, but it’s likely a local to utc time zone conversion bug. e.g. if you enter a payment after 4pm local time, it might show up as the previous day.
1. Go to http://localhost:8080/child-care-centres/1/2023-24/summary/payments
2. Enter a payment date.
3. Check to see if the date stays the same after saving.

# Implementation

Treat DataTypes.DATEONLY type as string to avoid timezone complexities. This might not work, but I don't see what else could be causing the paidOn time to change to a different day. Potentially a better option would be to use a timestamp column, and only convert the formatted dateonly string in the UI?

# Screenshots

Have not been able to recreate.

# Testing Instructions

Have not been able to reproduce, though these would be the likely steps: 
1. Go to http://localhost:8080/child-care-centres/1/2023-24/summary/payments
2. Enter a payment date after 4pm (or maybe 5pm)
3. Check to see if the date stays the same after saving.