### PR TITLE
ELCC-45: Payments Aren’t Persisting Against the Correct Centre and Fiscal Year on Save

### DIFF
--- a/web/src/api/http-client.ts
+++ b/web/src/api/http-client.ts
@@ -22,9 +22,16 @@ httpClient.interceptors.request.use(async (config) => {
   return config
 })
 
-httpClient.interceptors.response.use(null, (error) => {
-  // Any status codes that falls outside the range of 2xx causes this function to trigger
-  if (error?.response?.data?.message) {
+// Any status codes that falls outside the range of 2xx causes this function to trigger
+httpClient.interceptors.response.use(null, async (error) => {
+  // Auth0 error type is unknown but it sets the error.error property to "login_required"
+  // Bounce the user if they hit a login required error when trying to access a protected route
+  // It would probably be better to move this code to a route guard or something?
+  if (error?.error === "login_required") {
+    await auth0.loginWithRedirect({
+      appState: { targetUrl: window.location.pathname },
+    })
+  } else if (error?.response?.data?.message) {
     throw new Error(error.response.data.message)
   } else if (error.message) {
     throw new Error(error.message)

--- a/web/src/modules/centre/views/CentreList.vue
+++ b/web/src/modules/centre/views/CentreList.vue
@@ -51,6 +51,7 @@
           :search="search"
           class="row-clickable"
           @click:row="tableRowClick"
+          @dblclick:row="goToCentre"
         ></v-data-table>
       </v-card>
     </v-col>


### PR DESCRIPTION
Fixes https://yg-hpw.atlassian.net/browse/ELCC-45

# Context

User report
> None of the payments that I entered (and hit save) remain after logging out. I did it multiple times, it disappeared every time.

Could not re-create; however, this may have been fixed by fixing payment -> fiscal year reactivity in https://github.com/icefoganalytics/elcc-data-management/pull/67

## Investigation

![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/578c1a1f-7390-49f0-84f5-14501c89babe)

Lots of payments are showing up in the database against the same fiscal year and center id. This is likely the result of a hard-coded center id and/or fiscal year in the data entry. Or the data entry not being reactive to the currently selected fiscal year/center id.

# Implementation

Force invalid api calls to bounce the user to the login page. There have been reports that payments aren't persisting after logout, and since I haven't been able to recreate the issue locally, the only other thing I can think of is that the user's session had silently expired. This is generally a good practice, though it might be better to handle this in a route guard or global watcher or something.
Support double click go to on center list.

# Testing Instructions

1. Boot the app via `dev up`
2. Check that the app complies, and that you can log in at http://localhost:8080.
3. Go to http://localhost:8080/child-care-centres.
4. Double click a child care center to go to the center details. (new)
6. Go to the Summary -> Payments tab.
7. Switch the fiscal year, and then enter some payments
8. Reload the page and see if they persist after refresh.
