### PR TITLE
Fix Reactivity Bug in Employees -> Month Page

### DIFF
--- a/web/src/api/fiscal-periods-api.ts
+++ b/web/src/api/fiscal-periods-api.ts
@@ -37,8 +37,8 @@ export const fiscalPeriodsApi = {
         const { dateStart, dateEnd, createdAt, updatedAt } = fiscalPeriod
         return {
           ...fiscalPeriod,
-          dateStart: DateTimeUtils.fromISO(dateStart),
-          dateEnd: DateTimeUtils.fromISO(dateEnd),
+          dateStart: DateTimeUtils.fromISO(dateStart).toUTC(),
+          dateEnd: DateTimeUtils.fromISO(dateEnd).toUTC(),
           createdAt: DateTimeUtils.fromISO(createdAt),
           updatedAt: DateTimeUtils.fromISO(updatedAt),
         }

--- a/web/src/modules/centre/pages/CentreDashboardEmployeesMonthlyWorksheetPage.vue
+++ b/web/src/modules/centre/pages/CentreDashboardEmployeesMonthlyWorksheetPage.vue
@@ -31,8 +31,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watchEffect } from "vue"
-import moment from "moment" // TODO: deprecated; replace with luxon
+import { computed, ref, watch } from "vue"
 
 import { useNotificationStore } from "@/store/NotificationStore"
 import fiscalPeriodsApi, { FiscalPeriod } from "@/api/fiscal-periods-api"
@@ -65,7 +64,7 @@ const fiscalPeriodFormattedDate = computed(() => {
   if (isEmpty(fiscalPeriod.value)) return ""
 
   const { dateStart } = fiscalPeriod.value
-  const formattedDate = moment.utc(dateStart).format("MMMM YYYY")
+  const formattedDate = dateStart.toFormat("MMMM yyyy")
   return formattedDate
 })
 
@@ -97,9 +96,13 @@ async function fetchFiscalPeriods(fiscalYear: string, month: string) {
   }
 }
 
-watchEffect(async () => {
-  await fetchFiscalPeriods(props.fiscalYearSlug, props.month)
-})
+watch(
+  () => [props.fiscalYearSlug, props.month],
+  async ([newFiscalYearSlug, newMonth], _) => {
+    await fetchFiscalPeriods(newFiscalYearSlug, newMonth)
+  },
+  { immediate: true }
+)
 </script>
 
 <style scoped>


### PR DESCRIPTION
Fixes https://yg-hpw.atlassian.net/browse/ELCC-48

# Context

https://elcc.ynet.gov.yk.ca/child-care-centres/2/2022-23/employees/april navigate around the sub-title can get out of date.
![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/7a80d718-032a-496a-949e-d4908c4d7749)
Or maybe its just broken for Center#2 FiscalPeriod → 2022-23 → April?

# Implementation

The original bug was caused by parsing a Luxon DateTime with moment, which had an unpredictable effect.
There was also a secondary bug with where the Luxon date was converting to local time, often showed the date-only object a day off. The solution to this was to parse date only objects to UTC, and set the local to UTC for them as well.
I also swapped the `watchEffect` to a `watch` of the relevant props, as `watch` is more targeted and predictable for complex functions. 

# Screenshots

![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/1669e64b-0ca4-48c2-bcad-ffc15bcb82c1)

# Testing Instructions

1. Boot the app via `dev up`
2. Check that the app complies, and that you can log in at http://localhost:8080.
3. Check that you can go to http://localhost:8080/child-care-centres/1/2023-24/employees/april.
4. Observe that the worksheet sub-title no longer shows "January 2024". It now shows "April 2023".
5. Switch month sub-tabs, and check that the sub-title is reactive again.
