### PR TITLE
ELCC-50: Fix Payment Date Returns Incorrect Date On Page Reload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,11 +46,10 @@ ARG GIT_COMMIT_HASH
 ENV RELEASE_TAG=${RELEASE_TAG}
 ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH}
 
-RUN apk add --no-cache tzdata
-
-RUN cp /usr/share/zoneinfo/America/Whitehorse /etc/localtime
-RUN echo "America/Whitehorse" > /etc/timezone
-RUN apk del tzdata
+# Persists TZ=UTC effect after container build and into container run
+# Ensures dates/times are consistently formated as UTC
+# Conversion to local time should happen in the UI
+ENV TZ=UTC
 
 ENV NODE_ENV=production
 USER node

--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -2,6 +2,7 @@ version: "3"
 
 x-default-environment: &default-environment
   NODE_ENV: development
+  TZ: "UTC"
   DB_HOST: db
   DB_USER: sa
   DB_NAME: elcc_development
@@ -80,7 +81,6 @@ services:
       <<: *default-environment
       DB_HOST: "localhost"
       MSSQL_SA_PASSWORD: *default-db-password
-      TZ: "America/Whitehorse"
       ACCEPT_EULA: "Y"
     ports:
       - "1433:1433"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: "3"
+
 services:
   app:
     build: .
@@ -20,7 +21,7 @@ services:
     environment:
       # default user is `sa`
       MSSQL_SA_PASSWORD: "${DB_PASS}"
-      TZ: "America/Whitehorse"
+      TZ: "UTC"
       ACCEPT_EULA: "Y"
     ports:
       - "1433:1433"


### PR DESCRIPTION
Fixes https://yg-hpw.atlassian.net/browse/ELCC-50

Relates to:

- https://github.com/sequelize/sequelize/issues/11597

# Context

See https://elcc.ynet.gov.yk.ca/child-care-centres/2/2022-23/summary/payments

When the first advance is updated to 2022-04-01, it updates correctly, as seen from the Network pane, but the list view endpoint returns the previous day.

![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/cde4cbfd-3b20-412f-ae87-178f36f98241)

# Implementation

Issue is caused by how Sequelize handles "DATEONLY" fields. When not using a non-UTC timezone the dateonly fields are cast to the local timezone on data retrieval. The solution is to switch production node environment timezone to UTC.

# Testing Instructions

1. Edit the `docker-compose.development.yaml` and set the TZ value to `"America/Whitehorse"`
2. Boot the app via `dev up`
3. Check that the app complies, and that you can log in at http://localhost:8080.
4. Check that you can go to http://localhost:8080/child-care-centres/1/2023-24/summary/payments.
5. Create or save a new payment with the Payment Date set to `2023-04-01`.
6. Note that while the payment looks correct after saving, if you reload the page it will reveal the bug as the Payment Date is then converted to `2023-03-31` - immediately upon retrieval from the database.
7. Now repeat the steps with the TZ set to `UTC` and the Payment Date will no longer be cast back a day.
