### PR TITLE
ELCC49: Fix Expense Calculation on Summary -> Reconciliation Page Is Off By An Unknown Amount

### DIFF
--- a/web/src/modules/centre/pages/CentreDashboardSummaryReconciliationPage.vue
+++ b/web/src/modules/centre/pages/CentreDashboardSummaryReconciliationPage.vue
@@ -225,7 +225,7 @@ watch<[number, string], true>(
     fiscalPeriods.value = await fetchFiscalPeriods(newFiscalYearSlug)
     const fiscalPeriodIds = fiscalPeriods.value.map((fiscalPeriod) => fiscalPeriod.id)
     await fetchEmployeeBenefits(newCentreId, fiscalPeriodIds)
-    await fundingSubmissionLineJsonsStore.initialize({
+    await fundingSubmissionLineJsonsStore.fetch({
       where: {
         centreId: newCentreId,
         fiscalYear: newFiscalYear,

--- a/web/src/modules/centre/pages/CentreDashboardSummaryReconciliationPage.vue
+++ b/web/src/modules/centre/pages/CentreDashboardSummaryReconciliationPage.vue
@@ -35,14 +35,12 @@
               bottom
             >
               <template #activator="{ props }">
-                {{ formatMoney(centsToDollars(expense.amountInCents)) }}
-                <sup class="asterisk-icon">
-                  <v-icon
-                    size="small"
-                    v-bind="props"
-                    >mdi-asterisk-circle-outline</v-icon
-                  >
-                </sup>
+                <span v-bind="props">
+                  {{ formatMoney(centsToDollars(expense.amountInCents)) }}
+                  <sup class="asterisk-icon">
+                    <v-icon size="small">mdi-asterisk-circle-outline</v-icon>
+                  </sup>
+                </span>
               </template>
               <span class="text-white">This expense includes estimated values.</span>
             </v-tooltip>

--- a/web/src/modules/centre/pages/CentreDashboardSummaryReconciliationPage.vue
+++ b/web/src/modules/centre/pages/CentreDashboardSummaryReconciliationPage.vue
@@ -1,5 +1,14 @@
 <template>
-  <v-table class="ma-4">
+  <v-skeleton-loader
+    v-if="isLoading"
+    :rows="10"
+    :columns="5"
+    type="table"
+  />
+  <v-table
+    v-else
+    class="ma-4"
+  >
     <thead>
       <tr>
         <th class="text-left"></th>
@@ -10,13 +19,6 @@
       </tr>
     </thead>
     <tbody>
-      <v-skeleton-loader
-        v-if="isLoading"
-        :loading="true"
-        :rows="10"
-        :columns="5"
-        type="table"
-      />
       <template
         v-for="({ label, expense, payment, runningTotal }, adjustmentIndex) in adjustmentRows"
         :key="`adjustment-${adjustmentIndex}`"

--- a/web/src/modules/centre/pages/CentreDashboardSummaryReconciliationPage.vue
+++ b/web/src/modules/centre/pages/CentreDashboardSummaryReconciliationPage.vue
@@ -279,8 +279,8 @@ async function buildExpenseValues(fiscalPeriods: FiscalPeriod[]): Promise<Adjust
       const actualSectionsTotal = sumBy(linesForMonth, "actualComputedTotal")
       const estimatedSectionsTotal = sumBy(linesForMonth, "estimatedComputedTotal")
 
-      const includesEstimates = actualSectionsTotal > 0
-      const sectionsTotal = includesEstimates ? actualSectionsTotal : estimatedSectionsTotal
+      const includesEstimates = actualSectionsTotal === 0
+      const sectionsTotal = includesEstimates ? estimatedSectionsTotal : actualSectionsTotal
 
       expense.includesEstimates ||= includesEstimates
       expense.amountInCents += dollarsToCents(sectionsTotal)
@@ -317,13 +317,10 @@ function injectEmployeeBenefitMonthlyCost(expense: Adjustment, month: string): v
     employerCostActual,
     grossPayrollMonthlyActual * costCapPercentage
   )
-  const isCostActual = actualPaidAmount > 0
-  const paidAmountInDollars = isCostActual ? actualPaidAmount : estimatedPaidAmount
+  const includesEstimates = actualPaidAmount === 0
+  const paidAmountInDollars = includesEstimates ? estimatedPaidAmount : actualPaidAmount
 
-  if (!isCostActual) {
-    expense.includesEstimates = true
-  }
-
+  expense.includesEstimates ||= includesEstimates
   expense.amountInCents += dollarsToCents(paidAmountInDollars)
 }
 
@@ -369,13 +366,12 @@ async function lazyInjectWageEnhancementMonthlyCost(expense: Adjustment, month: 
   const wageEnhancementsEstimatedTotal = wageEnhancementsEstimatedSubtotal * (1 + EI_CPP_WCB_RATE)
   const wageEnhancementsActualTotal = wageEnhancementsActualSubtotal * (1 + EI_CPP_WCB_RATE)
 
-  const isCostActual = wageEnhancementsActualTotal > 0
-  const totalInDollars = isCostActual ? wageEnhancementsActualTotal : wageEnhancementsEstimatedTotal
+  const includesEstimates = wageEnhancementsActualTotal === 0
+  const totalInDollars = includesEstimates
+    ? wageEnhancementsEstimatedTotal
+    : wageEnhancementsActualTotal
 
-  if (!isCostActual) {
-    expense.includesEstimates = true
-  }
-
+  expense.includesEstimates ||= includesEstimates
   expense.amountInCents += dollarsToCents(totalInDollars)
 }
 

--- a/web/src/modules/centre/pages/CentreDashboardSummaryReconciliationPage.vue
+++ b/web/src/modules/centre/pages/CentreDashboardSummaryReconciliationPage.vue
@@ -279,7 +279,7 @@ async function buildExpenseValues(fiscalPeriods: FiscalPeriod[]): Promise<Adjust
       const actualSectionsTotal = sumBy(linesForMonth, "actualComputedTotal")
       const estimatedSectionsTotal = sumBy(linesForMonth, "estimatedComputedTotal")
 
-      const includesEstimates = actualSectionsTotal === 0
+      const includesEstimates = estimatedSectionsTotal > 0 && actualSectionsTotal === 0
       const sectionsTotal = includesEstimates ? estimatedSectionsTotal : actualSectionsTotal
 
       expense.includesEstimates ||= includesEstimates
@@ -317,7 +317,7 @@ function injectEmployeeBenefitMonthlyCost(expense: Adjustment, month: string): v
     employerCostActual,
     grossPayrollMonthlyActual * costCapPercentage
   )
-  const includesEstimates = actualPaidAmount === 0
+  const includesEstimates = estimatedPaidAmount > 0 && actualPaidAmount === 0
   const paidAmountInDollars = includesEstimates ? estimatedPaidAmount : actualPaidAmount
 
   expense.includesEstimates ||= includesEstimates
@@ -366,7 +366,7 @@ async function lazyInjectWageEnhancementMonthlyCost(expense: Adjustment, month: 
   const wageEnhancementsEstimatedTotal = wageEnhancementsEstimatedSubtotal * (1 + EI_CPP_WCB_RATE)
   const wageEnhancementsActualTotal = wageEnhancementsActualSubtotal * (1 + EI_CPP_WCB_RATE)
 
-  const includesEstimates = wageEnhancementsActualTotal === 0
+  const includesEstimates = wageEnhancementsEstimatedTotal > 0 && wageEnhancementsActualTotal === 0
   const totalInDollars = includesEstimates
     ? wageEnhancementsEstimatedTotal
     : wageEnhancementsActualTotal


### PR DESCRIPTION
Fixes https://yg-hpw.atlassian.net/browse/ELCC-49

# Context

See https://elcc.ynet.gov.yk.ca/child-care-centres/2/2022-23/summary/reconciliation

When expense calculation is complicated the value can be offset by a a few 100 dollars or something. This error amount is too high for cent/dollar conversion or rounding, but too low to easily identify as a single missing concept.

After investigation, it looks like the reconciliation tab expenses column does not seem to include “estimated” values from the Worksheets → :month tab.

# Implementation

1. Add estimated values for funding submission line jsons.
2. Currently I'm mixing and matching expenses and estimates. When any "actual" value exists I use all "actuals" for that expenses type. However, it might make more sense to use _all_ actuals, or _all_ estimates?
3. I fixed bug in reactivity of Summary -> Reconciliation page; previously worksheets changes required a page reload to propagate.

NOTE: I've asked Miranda to clarify the business logic for when to sum "actual" vs. "estimated" expenses.

# Screenshots

Summary -> Reconciliation
![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/047d9819-4d2b-4f50-ad2a-14635348e544)

Summary -> Payments
![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/1c910002-3f82-4619-9581-7b6424af0dde)

WorkSheets -> April
![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/b7397d17-287b-463e-a7e1-8e52877ea2d9)

Employees -> April
![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/ef971248-8415-48a8-88e1-55cc120417fc)

Tooltip
![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/d2d83404-d265-4076-8766-b7a0415cacff)

# Testing Instructions

1. Boot the app via `dev up`
2. Check that the app complies, and that you can log in at http://localhost:8080.
3. Check that you can go to http://localhost:8080/child-care-centres/1/2023-24/summary/reconciliation.
5. Look at the April expenses column.
6. Go to the Summary -> Payments tab and add a payment for `2023-04-01`
7. Go back to the Reconciliation -> Summary tab and check that the payment shows up in the "Advance" column.
8. Go to the Worksheets -> April tab (http://localhost:8080/child-care-centres/1/2023-24/worksheets/april).
9. Add some estimated values for April, but be sure to leave all Actual values as $0.00.
10. Go back to the Reconciliation -> Summary tab and check that the worksheet expenses now show up for the April line, and show up with an (*) with the appropriate tooltip. Make sure that all other expenses are blank.
11. Go back to the Worksheets -> April tab and add an actual expense.
12. Go back to the Reconciliation -> Summary tab and check that the worksheet expenses for the April line match the new actual expenses.
13. Go to the Employees -> April tab and add an estimate Employee Benefits expense.
14. Go back to the Reconciliation -> Summary tab and check that the worksheet expenses for the April line includes this new estimated expense.
15. Go back to the Employees -> April tab and add an actual Employee Benefits expense.
16. Go back to the Reconciliation -> Summary tab and check that the worksheet expenses for the April line includes this new actual expense and the tooltip is no longer present.
17. Repeat the above steps with the Employees -> April tab -> Wage enhancements section.
