### PR TITLE
ELCC-60: Add "enter" Keyboard Shortcut To Data Entry in Employees Tab -> Employee Benefits Section

### DIFF
--- a/web/src/components/CurrencyInput.vue
+++ b/web/src/components/CurrencyInput.vue
@@ -6,6 +6,7 @@
     @focus="onFocus"
     @blur="onBlur"
     @keydown.escape="resetValue"
+    @keydown.enter="onEnter"
   />
 </template>
 
@@ -65,6 +66,10 @@ async function onBlur() {
   } else {
     emit("update:modelValue", numberValue.value)
   }
+}
+
+function onEnter() {
+  emit("update:modelValue", numberValue.value)
 }
 
 function resetValue() {


### PR DESCRIPTION
Fixes https://yg-hpw.atlassian.net/browse/ELCC-60

# Context
## User Report

> I went in today and started inputting data into the 23/24 sheet for Bright Stars.
> I noticed:
>   2. Pressing "enter" in the worksheets inputs the data, but does not in the benefits

## Reproduction Instructions

1. Go to the [http://localhost:8080/child-care-centres](http://localhost:8080/child-care-centres) page.
2. Select a Child Care Centre by double-clicking on it, or adding a new one via the top right call-to-action.
3. Select the 2023/24 fiscal year from the top right selector thing.
4. Select the Employees tab.
5. Type some data in the Gross Payroll row of the Employee Benefits section.
6. Press "enter", note that data is not entered. Press "tab", note that data is entered.
7. Scroll down and press the "Save" button.
8. Go to the "Worksheets" tab.
9. Click the "add worksheets for xxx" if no worksheets exist.
10. Enter some data in the worksheet and press "enter", note that data is entered.
11. Click the "Save" button at the top of the worksheet tab.

# Implementation

Make "enter" trigger "input" event in CurrencyInput component.

## Questions

I'm not sure why the end user wants "enter" support, as "tab" does the same thing, and also switches to the next input? I'm thinking there might be a more complex effect that "enter" should perform? We might want to build more Excel style helpers so that enter does the same thing as it does in Excel?

# Screenshots

Same as before, just for context.
![image](https://github.com/icefoganalytics/elcc-data-management/assets/23045206/036a65c2-0f9d-417b-aa27-15b01a5aa513)

# Testing Instructions

1. Boot the app via `dev up`
2. Check that the app complies, and that you can log in at http://localhost:8080.
3. Go to the [http://localhost:8080/child-care-centres](http://localhost:8080/child-care-centres) page.
4. Select a Child Care Centre by double-clicking on it, or adding a new one via the top right call-to-action.
5. Select the 2023/24 fiscal year from the top right selector thing.
6. Select the Employees tab.
7. Type some data in the Gross Payroll row of the Employee Benefits section.
8. Press "enter", note that data is not entered. Press "tab", note that data is entered.
9. Scroll down and press the "Save" button.
10. Go to the "Worksheets" tab.
11. Click the "add worksheets for xxx" if no worksheets exist.
12. Enter some data in the worksheet and press "enter", note that data is entered.
13. Click the "Save" button at the top of the worksheet tab.
