### PR TITLE
Change Second School Age (PT) to (FT)

### DIFF
--- a/api/src/db/data/funding-submission-lines.json
+++ b/api/src/db/data/funding-submission-lines.json
@@ -62,7 +62,7 @@
   {
     "fiscalYear": "2022/23",
     "sectionName": "Child Care Spaces",
-    "lineName": "School Age (PT)",
+    "lineName": "School Age (FT)",
     "fromAge": 5,
     "toAge": 6,
     "monthlyAmount": 500.0,
@@ -132,7 +132,7 @@
   {
     "fiscalYear": "2022/23",
     "sectionName": "Administration (10% of Spaces)",
-    "lineName": "School Age (PT)",
+    "lineName": "School Age (FT)",
     "fromAge": 5,
     "toAge": 6,
     "monthlyAmount": 50.0,
@@ -202,7 +202,7 @@
   {
     "fiscalYear": "2022/23",
     "sectionName": "Quality Program Enhancement",
-    "lineName": "School Age (PT)",
+    "lineName": "School Age (FT)",
     "fromAge": 5,
     "toAge": 6,
     "monthlyAmount": 97.33,
@@ -522,7 +522,7 @@
   {
     "fiscalYear": "2023/24",
     "sectionName": "Child Care Spaces",
-    "lineName": "School Age (PT)",
+    "lineName": "School Age (FT)",
     "fromAge": 5,
     "toAge": 6,
     "monthlyAmount": 500.0,
@@ -592,7 +592,7 @@
   {
     "fiscalYear": "2023/24",
     "sectionName": "Administration (10% of Spaces)",
-    "lineName": "School Age (PT)",
+    "lineName": "School Age (FT)",
     "fromAge": 5,
     "toAge": 6,
     "monthlyAmount": 50.0,
@@ -662,7 +662,7 @@
   {
     "fiscalYear": "2023/24",
     "sectionName": "Quality Program Enhancement",
-    "lineName": "School Age (PT)",
+    "lineName": "School Age (FT)",
     "fromAge": 5,
     "toAge": 6,
     "monthlyAmount": 97.33,


### PR DESCRIPTION
Depends on:

- (delete this section if pull request has no dependencies)

Relates to:

- https://yg-hpw.atlassian.net/browse/ELCC-25

# Context

Currently there are 2 School Age (PT) and one should be School Age (FT).  This is correct in the Administration panel but not being reflected on the actual data entry screens.

The Admin UI located at https://elcc.ynet.gov.yk.ca/administration/submission-lines, lets us change the data for new worksheets, but it doesn't update the labeling of existing worksheets.

![image](https://github.com/user-attachments/assets/f70c5b29-24fe-43c2-818f-494e6c65cdba)

# Implementation

1. Fix duplicates in funding submission line names in the seeds; Second "School Age (PT)" should have been called "School Age (FT)".
2. Write some SQL queries to fix up the data.

<details><summary><code>script-1-clean-up-funding-submision-line-jsons-values-column.sql</code></summary>
<p>

```sql
WITH second_occurrence_lines AS (
  SELECT
    funding_submission_line_jsons.id,
    funding_submission_line_jsons.[values],
    funding_submission_line.[key] AS json_array_index,
    ROW_NUMBER() OVER (
      PARTITION BY funding_submission_line_jsons.id,
      JSON_VALUE(funding_submission_line.[value], '$.sectionName'),
      JSON_VALUE(funding_submission_line.[value], '$.lineName')
      ORDER BY
        funding_submission_line.[key]
    ) AS occurrence_number
  FROM
    funding_submission_line_jsons
    CROSS APPLY OPENJSON(funding_submission_line_jsons.[values]) AS funding_submission_line
  WHERE
    JSON_VALUE(funding_submission_line.[value], '$.lineName') = 'School Age (PT)'
)
UPDATE
  funding_submission_line_jsons
SET
  [values] = JSON_MODIFY(
    funding_submission_line_jsons.[values],
    '$[' + CAST(second_occurrence_lines.json_array_index AS nvarchar(10)) + '].lineName',
    'School Age (FT)'
  )
FROM
  funding_submission_line_jsons
  INNER JOIN second_occurrence_lines ON funding_submission_line_jsons.id = second_occurrence_lines.id
WHERE
  second_occurrence_lines.occurrence_number = 2;
```

</p>
</details> 

<details><summary><code>script-2-clean-up-funding-submission-lines.sql</code></summary>
<p>

```sql
WITH duplicate_lines AS (
  SELECT
    id,
    ROW_NUMBER() OVER (
      PARTITION BY fiscal_year,
      section_name,
      line_name
      ORDER BY
        created_at
    ) AS row_num
  FROM
    funding_submission_lines
  WHERE
    line_name = 'School Age (PT)'
)
UPDATE
  funding_submission_lines
SET
  line_name = 'School Age (FT)'
WHERE
  id IN (
    SELECT
      id
    FROM
      duplicate_lines
    WHERE
      row_num = 2
  );
```

</p>
</details> 

# Screenshots

![image](https://github.com/user-attachments/assets/d661c6ea-7c1d-4510-b4f2-6a2523bf9c0b)

# Testing Instructions

1. Drop the database via `dev down -v`
2. Boot the app and run the seeds via `dev up`
3. Check that the app complies, and that you can log in at http://localhost:8080.
4. Go to http://localhost:8080/child-care-centres/1/2022-23/worksheets/april, and create the worksheets if they don't exist.
5. Check that in the section "Administration (10% of Spaces)" there is a "School Age (PT)" and a "School Age (FT)" column.

# Production Fixup instructions.
1. Fix the data located in the admin page https://elcc.ynet.gov.yk.ca/administration/submission-lines.
2. Run the first sql script against the production database.
3. Run the second sql script against the production database (may be obviated by step 1)
